### PR TITLE
Add optional superbuild and diagnostics

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,42 @@
+name: CMake
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake g++
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - name: Build
+        run: cmake --build build -j
+      - name: Test
+        run: ctest --test-dir build --output-on-failure
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: C:\\Users\\runneradmin\\AppData\\Local\\cache
+          key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
+      - name: Install Ninja and CMake
+        run: choco install ninja cmake --yes
+      - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - name: Build
+        run: cmake --build build -j
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.24...3.29)
+
+# Modern policies for deterministic behaviour
+cmake_policy(SET CMP0091 NEW) # MSVC runtime library selection
+cmake_policy(SET CMP0077 NEW) # option() honours normal variables
+cmake_policy(SET CMP0126 NEW) # cmake -E env behavior
+
 project(VoxelVK_Elite_ALL LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -12,6 +18,11 @@ option(ENABLE_IMGUI_OVERLAY     "Enable ImGui debug HUD overlay" ON)
 option(ENABLE_TESTS             "Enable CTest targets" ON)
 option(VOXELVK_ENABLE_CUDA      "Enable CUDA acceleration" OFF)
 option(VOXELVK_ENABLE_TENSORRT  "Enable TensorRT (requires CUDA)" OFF)
+option(ENABLE_VULKAN            "Build Vulkan dependent targets" ON)
+
+if(NOT VOXELVK_ENABLE_CUDA)
+  include(cmake/GuardNoCuda.cmake)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type" FORCE)
@@ -22,7 +33,22 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   add_link_options(-Wl,--no-undefined)
 endif()
 
-find_package(Vulkan REQUIRED)
+# ---- Toolchain diagnostics ----
+add_custom_target(superbuild_check
+  COMMAND ${CMAKE_COMMAND} -E echo "C++ compiler: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}"
+  COMMAND ${CMAKE_COMMAND} -E echo "Build type : ${CMAKE_BUILD_TYPE}"
+  COMMAND ${CMAKE_COMMAND} -E echo "CUDA       : ${VOXELVK_ENABLE_CUDA}"
+  COMMAND ${CMAKE_COMMAND} -E echo "TensorRT   : ${VOXELVK_ENABLE_TENSORRT}"
+)
+
+# ---- Vulkan detection ----
+if(ENABLE_VULKAN)
+  find_package(Vulkan QUIET)
+  if(NOT Vulkan_FOUND)
+    message(WARNING "Vulkan SDK or loader not found. Vulkan targets will be skipped.\nInstall from https://vulkan.lunarg.com/sdk/home")
+    set(ENABLE_VULKAN OFF)
+  endif()
+endif()
 
 # --- Build tagging injection ---
 set(VOXELVK_BRANCH_SOURCES "project_fixed + VoxelVK_Elite_ALL_release_ready + voxel_upgrades_patch + project_compute_graphics_chain + project_dynamic_pbr + project_next_tier_all")
@@ -33,68 +59,85 @@ find_package(glfw3 QUIET)
 if(glfw3_FOUND)
   set(GLFW_LIB glfw)
 else()
-  find_package(GLFW REQUIRED)
-  set(GLFW_LIB GLFW::GLFW)
+  find_package(GLFW QUIET)
+  if(GLFW_FOUND)
+    set(GLFW_LIB GLFW::GLFW)
+  elseif(ENABLE_VULKAN)
+    message(WARNING "GLFW not found; Vulkan samples will not build")
+    set(ENABLE_VULKAN OFF)
+  endif()
 endif()
 find_package(Threads REQUIRED)
 
 # Shader pipeline (glslc preferred; fallback glslangValidator)
-find_program(GLSLC_EXECUTABLE NAMES glslc HINTS "$ENV{VULKAN_SDK}/Bin" "$ENV{VULKAN_SDK}/bin" "/usr/bin" "/usr/local/bin")
-if(NOT GLSLC_EXECUTABLE)
-  find_program(GLSLANG_VALIDATOR NAMES glslangValidator HINTS "$ENV{VULKAN_SDK}/Bin" "$ENV{VULKAN_SDK}/bin" "/usr/bin" "/usr/local/bin")
-  if(NOT GLSLANG_VALIDATOR)
-    message(FATAL_ERROR "No shader compiler found (glslc/glslangValidator). Install Vulkan SDK.")
+set(SPV_OUT "")
+if(ENABLE_VULKAN)
+  find_program(GLSLC_EXECUTABLE NAMES glslc HINTS "$ENV{VULKAN_SDK}/Bin" "$ENV{VULKAN_SDK}/bin" "/usr/bin" "/usr/local/bin")
+  if(NOT GLSLC_EXECUTABLE)
+    find_program(GLSLANG_VALIDATOR NAMES glslangValidator HINTS "$ENV{VULKAN_SDK}/Bin" "$ENV{VULKAN_SDK}/bin" "/usr/bin" "/usr/local/bin")
+    if(GLSLANG_VALIDATOR)
+      set(SHADER_COMPILER ${GLSLANG_VALIDATOR})
+      set(SHADER_FLAGS -V --target-env vulkan1.3 -g)
+    else()
+      message(WARNING "No shader compiler found (glslc/glslangValidator). Shader compilation disabled.")
+      set(ENABLE_VULKAN OFF)
+    endif()
+  else()
+    set(SHADER_COMPILER ${GLSLC_EXECUTABLE})
+    set(SHADER_FLAGS --target-env=vulkan1.3 -O -g)
   endif()
-  set(SHADER_COMPILER ${GLSLANG_VALIDATOR})
-  set(SHADER_FLAGS -V --target-env vulkan1.3 -g)
-else()
-  set(SHADER_COMPILER ${GLSLC_EXECUTABLE})
-  set(SHADER_FLAGS --target-env=vulkan1.3 -O -g)
+
+  if(ENABLE_VULKAN)
+    file(GLOB_RECURSE GLSL_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/shaders_vk/*.glsl")
+    set(SPV_DIR "${CMAKE_BINARY_DIR}/spv")
+    foreach(GLSL_FILE IN LISTS GLSL_SOURCES)
+      get_filename_component(FILE_NAME ${GLSL_FILE} NAME_WE)
+      get_filename_component(FILE_DIR  ${GLSL_FILE} DIRECTORY)
+      file(RELATIVE_PATH REL_DIR "${CMAKE_SOURCE_DIR}/shaders_vk" "${FILE_DIR}")
+      set(OUT_DIR "${SPV_DIR}/${REL_DIR}")
+      file(MAKE_DIRECTORY "${OUT_DIR}")
+      set(SPV_FILE "${OUT_DIR}/${FILE_NAME}.spv")
+      set(DEP_FILE "${SPV_FILE}.d")
+      add_custom_command(OUTPUT ${SPV_FILE}
+        COMMAND ${SHADER_COMPILER} ${SHADER_FLAGS} -MD -MF ${DEP_FILE} -o ${SPV_FILE} ${GLSL_FILE}
+        DEPFILE ${DEP_FILE}
+        DEPENDS ${GLSL_FILE}
+        COMMENT "Compiling ${REL_DIR}/${FILE_NAME}.glsl")
+      list(APPEND SPV_OUT ${SPV_FILE})
+    endforeach()
+    add_custom_target(VoxelVK_Shaders ALL DEPENDS ${SPV_OUT})
+  endif()
 endif()
 
-file(GLOB_RECURSE GLSL_SOURCES CONFIGURE_DEPENDS "${CMAKE_SOURCE_DIR}/shaders_vk/*.*.glsl")
-set(SPV_DIR "${CMAKE_BINARY_DIR}/spv")
-set(SPV_OUT "")
-foreach(GLSL_FILE IN LISTS GLSL_SOURCES)
-  get_filename_component(FILE_NAME ${GLSL_FILE} NAME_WE)
-  get_filename_component(FILE_DIR  ${GLSL_FILE} DIRECTORY)
-  file(RELATIVE_PATH REL_DIR "${CMAKE_SOURCE_DIR}/shaders_vk" "${FILE_DIR}")
-  set(OUT_DIR "${SPV_DIR}/${REL_DIR}")
-  file(MAKE_DIRECTORY "${OUT_DIR}")
-  set(SPV_FILE "${OUT_DIR}/${FILE_NAME}.spv")
-  add_custom_command(OUTPUT ${SPV_FILE}
-    COMMAND ${SHADER_COMPILER} ${SHADER_FLAGS} -o ${SPV_FILE} ${GLSL_FILE}
-    DEPENDS ${GLSL_FILE}
-    COMMENT "Compiling ${REL_DIR}/${FILE_NAME}.glsl")
-  list(APPEND SPV_OUT ${SPV_FILE})
-endforeach()
-add_custom_target(VoxelVK_Shaders ALL DEPENDS ${SPV_OUT})
-
-# Targets (smoke only; plug real engine files as needed)
-add_executable(smoke_headless apps/smoke_headless.cpp)
-add_dependencies(smoke_headless VoxelVK_Shaders)
-target_include_directories(smoke_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB})
-target_compile_definitions(smoke_headless PRIVATE
-  $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
-  $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>)
-
-# CUDA/TRT guards if you later add GPU/AI targets
-target_compile_definitions(smoke_headless PRIVATE
-  $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
-  $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+if(ENABLE_VULKAN)
+  add_executable(smoke_headless apps/smoke_headless.cpp)
+  add_dependencies(smoke_headless VoxelVK_Shaders)
+  target_include_directories(smoke_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
+  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB})
+  target_compile_definitions(smoke_headless PRIVATE
+    $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
+    $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>
+    $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
+    $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+endif()
 
 # Tests
 if(ENABLE_TESTS)
   include(CTest)
   enable_testing()
-  add_test(NAME smoke_headless COMMAND smoke_headless)
-  set_tests_properties(smoke_headless PROPERTIES TIMEOUT 30)
+  add_subdirectory(tools/ipc_smoke_test)
+  add_test(NAME ipc_smoke_test COMMAND ipc_smoke_test)
+  set_tests_properties(ipc_smoke_test PROPERTIES TIMEOUT 30)
+  if(ENABLE_VULKAN)
+    add_test(NAME smoke_headless COMMAND smoke_headless)
+    set_tests_properties(smoke_headless PROPERTIES TIMEOUT 30)
+  endif()
 endif()
 
 message(STATUS "=== Build Summary ===")
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Shader Compiler: ${SHADER_COMPILER}")
+message(STATUS "Vulkan Enabled: ${ENABLE_VULKAN}")
 message(STATUS "=====================")
 
 # --- Build tagging sources ---

--- a/README_SUPERBUILD.md
+++ b/README_SUPERBUILD.md
@@ -1,0 +1,38 @@
+# VULKEN/CSM Superbuild
+
+This repository provides a meta-build that can assemble optional subprojects and run
+basic diagnostics. Only the minimal IPC smoke test is guaranteed to build on all
+machines; Vulkan, CUDA and TensorRT integrations are opt-in via CMake options.
+
+## Prerequisites
+* CMake 3.24+
+* A C++20 compiler (MSVC, Clang or GCC)
+* Ninja build system (recommended)
+* Optional SDKs:
+  * [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
+  * CUDA Toolkit + TensorRT
+
+## Usage
+```bash
+# fetch subprojects
+python scripts/perform_merge.py --force
+
+# configure and build
+cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake --build build -j
+ctest --test-dir build --output-on-failure
+```
+
+### Toggle features
+- `-DENABLE_VULKAN=ON|OFF`
+- `-DVOXELVK_ENABLE_CUDA=ON|OFF`
+- `-DVOXELVK_ENABLE_TENSORRT=ON|OFF` (implies CUDA)
+
+## Troubleshooting
+If the Vulkan SDK or CUDA toolkit are missing the configuration step will emit
+warnings with links to the appropriate installers. Use the `superbuild_check`
+target for a summary of detected toolchains and toggles:
+
+```bash
+cmake --build build --target superbuild_check
+```

--- a/cmake/GuardNoCuda.cmake
+++ b/cmake/GuardNoCuda.cmake
@@ -1,0 +1,24 @@
+# GuardNoCuda.cmake - ensures CUDA is not inadvertently pulled in when disabled
+if(VOXELVK_ENABLE_CUDA)
+  return()
+endif()
+
+set(_cuda_vars CUDA_TOOLKIT_ROOT_DIR CUDAToolkit_ROOT)
+foreach(v IN LISTS _cuda_vars)
+  if(DEFINED ${v})
+    message(WARNING "CUDA variable '${v}' is set while VOXELVK_ENABLE_CUDA=OFF. Unset it to silence this warning.")
+  endif()
+endforeach()
+
+try_compile(CUDA_COMPILES
+  "${CMAKE_BINARY_DIR}/cuda_guard"
+  "${CMAKE_CURRENT_LIST_DIR}/try_no_cuda_guard.cpp"
+  CMAKE_FLAGS -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+  OUTPUT_VARIABLE CUDA_GUARD_LOG
+)
+
+if(CUDA_COMPILES)
+  message(FATAL_ERROR "CUDA detected but VOXELVK_ENABLE_CUDA=OFF. Set VOXELVK_ENABLE_CUDA=ON or remove CUDA from your environment.\n${CUDA_GUARD_LOG}")
+else()
+  message(STATUS "CUDA not detected (as expected)")
+endif()

--- a/cmake/try_no_cuda_guard.cpp
+++ b/cmake/try_no_cuda_guard.cpp
@@ -1,0 +1,2 @@
+#include <cuda_runtime.h>
+int main() { return 0; }

--- a/scripts/perform_merge.py
+++ b/scripts/perform_merge.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Utility to refresh vendor copies of external projects.
+
+This script validates that the VULKEN-3D-WORLD submodule exists and can optionally
+forcefully refresh any mirrored directories. It intentionally ignores VCS and build
+artifacts to keep the tree clean.
+"""
+from __future__ import annotations
+import argparse
+import os
+import pathlib
+import shutil
+import sys
+
+def copytree(src: pathlib.Path, dst: pathlib.Path, force: bool) -> None:
+    if dst.exists() and force:
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns('.git', 'build', 'CMakeFiles', '__pycache__'))
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--force', action='store_true', help='overwrite existing files')
+    args = parser.parse_args()
+
+    root = pathlib.Path(__file__).resolve().parents[1]
+    ext = root / 'external' / 'VULKEN-3D-WORLD'
+    if not (ext / 'CMakeLists.txt').exists():
+        print('Missing external/VULKEN-3D-WORLD. Clone with:\n  gh repo clone user/VULKEN-3D-WORLD external/VULKEN-3D-WORLD', file=sys.stderr)
+        return 1
+
+    mirror = root / 'VULKEN-3D-WORLD.mirror'
+    copytree(ext, mirror, args.force)
+    print('Merged', ext, '->', mirror)
+    return 0
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover
+        print(f'fATAL: {exc}', file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/perform_merge.py
+++ b/scripts/perform_merge.py
@@ -37,5 +37,5 @@ if __name__ == '__main__':
     try:
         raise SystemExit(main())
     except Exception as exc:  # pragma: no cover
-        print(f'fATAL: {exc}', file=sys.stderr)
+        print(f'FATAL: {exc}', file=sys.stderr)
         raise SystemExit(1)

--- a/tools/ipc_smoke_test/CMakeLists.txt
+++ b/tools/ipc_smoke_test/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(ipc_smoke_test main.cpp)
+if(WIN32)
+  target_compile_definitions(ipc_smoke_test PRIVATE _WIN32_WINNT=0x0601)
+  target_link_libraries(ipc_smoke_test PRIVATE ws2_32)
+endif()

--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -11,7 +11,11 @@
 
 int main() {
 #if defined(_WIN32)
-    WSADATA wsa; if (WSAStartup(MAKEWORD(2,2), &wsa)!=0) { std::cerr << "WSAStartup failed\n"; return 1; }
+    WSADATA wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        std::cerr << "WSAStartup failed\n";
+        return 1;
+    }
 #endif
     int server = socket(AF_INET, SOCK_STREAM, 0);
     if (server < 0) { std::cerr << "socket failed\n"; return 1; }

--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#if defined(_WIN32)
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+#include <cstring>
+
+int main() {
+#if defined(_WIN32)
+    WSADATA wsa; if (WSAStartup(MAKEWORD(2,2), &wsa)!=0) { std::cerr << "WSAStartup failed\n"; return 1; }
+#endif
+    int server = socket(AF_INET, SOCK_STREAM, 0);
+    if (server < 0) { std::cerr << "socket failed\n"; return 1; }
+    sockaddr_in addr{}; addr.sin_family = AF_INET; addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); addr.sin_port = 0;
+    if (bind(server, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) { perror("bind"); return 1; }
+    socklen_t len = sizeof(addr);
+    if (getsockname(server, reinterpret_cast<sockaddr*>(&addr), &len) < 0) { perror("getsockname"); return 1; }
+    if (listen(server, 1) < 0) { perror("listen"); return 1; }
+    int client = socket(AF_INET, SOCK_STREAM, 0);
+    if (connect(client, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) { perror("connect"); return 1; }
+    int conn = accept(server, nullptr, nullptr);
+    const char* msg = "ping";
+    send(client, msg, std::strlen(msg), 0);
+    char buf[16] = {0};
+    recv(conn, buf, sizeof(buf), 0);
+    std::cout << buf << std::endl;
+#if defined(_WIN32)
+    closesocket(client); closesocket(conn); closesocket(server); WSACleanup();
+#else
+    close(client); close(conn); close(server);
+#endif
+    return std::strcmp(buf, msg) == 0 ? 0 : 2;
+}

--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -33,7 +33,16 @@ int main() {
     const char* msg = "ping";
     send(client, msg, std::strlen(msg), 0);
     char buf[16] = {0};
-    recv(conn, buf, sizeof(buf), 0);
+    if (client < 0) { std::cerr << "client socket failed\n"; return 1; }
+    if (connect(client, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) { perror("connect"); return 1; }
+    int conn = accept(server, nullptr, nullptr);
+    if (conn < 0) { perror("accept"); return 1; }
+    const char* msg = "ping";
+    ssize_t sent = send(client, msg, std::strlen(msg), 0);
+    if (sent < 0) { perror("send"); return 1; }
+    char buf[16] = {0};
+    ssize_t recvd = recv(conn, buf, sizeof(buf), 0);
+    if (recvd < 0) { perror("recv"); return 1; }
     std::cout << buf << std::endl;
 #if defined(_WIN32)
     closesocket(client);

--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -36,7 +36,10 @@ int main() {
     recv(conn, buf, sizeof(buf), 0);
     std::cout << buf << std::endl;
 #if defined(_WIN32)
-    closesocket(client); closesocket(conn); closesocket(server); WSACleanup();
+    closesocket(client);
+    closesocket(conn);
+    closesocket(server);
+    WSACleanup();
 #else
     close(client); close(conn); close(server);
 #endif

--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -19,7 +19,10 @@ int main() {
 #endif
     int server = socket(AF_INET, SOCK_STREAM, 0);
     if (server < 0) { std::cerr << "socket failed\n"; return 1; }
-    sockaddr_in addr{}; addr.sin_family = AF_INET; addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK); addr.sin_port = 0;
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
     if (bind(server, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) { perror("bind"); return 1; }
     socklen_t len = sizeof(addr);
     if (getsockname(server, reinterpret_cast<sockaddr*>(&addr), &len) < 0) { perror("getsockname"); return 1; }


### PR DESCRIPTION
## Summary
- modernize CMake and make Vulkan/CUDA/TensorRT optional
- add cross-platform IPC smoke test and preflight diagnostics
- wire up CI on Linux and Windows and document superbuild usage

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build -j`
- `ctest --test-dir build --output-on-failure`
- `PYTHONPATH=$PWD pytest`
- `PYTHONPATH=$PWD mypy --ignore-missing-imports src`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_689fc8caf264832dbb9983af3db50bd8