### PR TITLE
Refactor IPC smoke test socket setup

### DIFF
--- a/tools/ipc_smoke_test/main.cpp
+++ b/tools/ipc_smoke_test/main.cpp
@@ -1,56 +1,56 @@
 #include <iostream>
 #ifdef _WIN32
-  #include <winsock2.h>
-  #include <ws2tcpip.h>
-  #pragma comment(lib, "ws2_32.lib")
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
 #else
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <arpa/inet.h>
-  #include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #endif
 
 int main() {
 #ifdef _WIN32
-    WSADATA wsa{};
-    if(WSAStartup(MAKEWORD(2,2), &wsa) != 0) {
-        std::cerr << "WSAStartup failed" << std::endl;
-        return 1;
-    }
+  WSADATA wsa{};
+  if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+    std::cerr << "WSAStartup failed" << std::endl;
+    return 1;
+  }
 #endif
-    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
-    if(sock < 0) {
-        std::cerr << "socket failed" << std::endl;
-        return 1;
-    }
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    addr.sin_port = htons(0);
-    if(bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-        std::cerr << "bind failed" << std::endl;
+
+  int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    std::cerr << "socket failed" << std::endl;
 #ifdef _WIN32
-        closesocket(sock);
-        WSACleanup();
-#else
-        close(sock);
+    WSACleanup();
 #endif
-        return 1;
-    }
+    return 1;
+  }
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons(0);
+
+  if (bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
+    std::cerr << "bind failed" << std::endl;
 #ifdef _WIN32
     closesocket(sock);
     WSACleanup();
 #else
     close(sock);
-    SocketGuard guard(sock);
-    sockaddr_in addr{};
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    addr.sin_port = htons(0);
-    if(bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-        std::cerr << "bind failed" << std::endl;
-        return 1;
-    }
-    std::cout << "IPC smoke OK" << std::endl;
-    return 0;
+#endif
+    return 1;
+  }
+
+#ifdef _WIN32
+  closesocket(sock);
+  WSACleanup();
+#else
+  close(sock);
+#endif
+
+  std::cout << "IPC smoke OK" << std::endl;
+  return 0;
 }


### PR DESCRIPTION
## Summary
- clean up IPC smoke test socket creation and binding
- rely on OS APIs for socket cleanup
- guard platform-specific cleanup with closing `#endif`

## Testing
- `PYTHONPATH=. pytest`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*
- `mypy .` *(fails: missing modules e.g., .capsule, .aabb, zstandard, lz4)*

------
https://chatgpt.com/codex/tasks/task_e_689fe102c204832d8a58fcf93251fec2