### PR TITLE
Add unit tests for RLE and chunk persistence

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,2 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,3 @@
-import os, sys
+import os
+import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_chunkstore.py
+++ b/tests/test_chunkstore.py
@@ -1,0 +1,18 @@
+import numpy as np
+from src.world.persistence import ChunkStore
+
+class DummyChunk:
+    def __init__(self, position, voxels):
+        self.position = position
+        self.voxels = voxels
+
+def test_chunkstore_save_and_load(tmp_path):
+    voxels = np.arange(8, dtype=np.uint8).reshape((2, 2, 2))
+    chunk = DummyChunk((0, 0), voxels)
+    store = ChunkStore(root=tmp_path, use_rle=True)
+    store.save_chunk_sync(chunk)
+    loaded = store.load_chunk(0, 0)
+    assert loaded is not None
+    assert np.array_equal(loaded["voxels"], voxels)
+    assert loaded["height"] == voxels.shape[1]
+    assert loaded["size"] == voxels.shape[2]

--- a/tests/test_rle.py
+++ b/tests/test_rle.py
@@ -1,0 +1,13 @@
+import numpy as np
+from src.world.rle import rle_encode, rle_decode
+
+def test_rle_roundtrip_small_arrays():
+    arrays = [
+        np.array([0, 0, 0, 1, 1, 2], dtype=np.uint8),
+        np.array([[1, 1], [2, 2]], dtype=np.uint8),
+        np.arange(8, dtype=np.uint8).reshape((2, 2, 2)),
+    ]
+    for arr in arrays:
+        vals, counts, shape = rle_encode(arr)
+        out = rle_decode(vals, counts, shape)
+        assert np.array_equal(out, arr)


### PR DESCRIPTION
## Summary
- add RLE encode/decode round-trip tests on small arrays
- verify ChunkStore saves and loads voxel chunks correctly

## Testing
- `pytest -q`
- `mypy --ignore-missing-imports src/world`
- `mypy --ignore-missing-imports tests/test_rle.py tests/test_chunkstore.py`
- `npx eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689fe10a6c58832d9d8c058ca49bd23b