### PR TITLE
Archive build outputs after CI tests

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -73,3 +73,12 @@ jobs:
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest --build-config ${{ matrix.build_type }}
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: build-${{ matrix.os }}-${{ matrix.c_compiler }}
+        path: |
+          ${{ steps.strings.outputs.build-output-dir }}/**
+          ${{ steps.strings.outputs.build-output-dir }}/spv/**
+        if-no-files-found: ignore

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,14 @@ jobs:
         run: cmake --build build -j
       - name: Test
         run: ctest --test-dir build --output-on-failure
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ runner.os }}
+          path: |
+            build/**
+            build/spv/**
+          if-no-files-found: ignore
 
   windows:
     runs-on: windows-latest
@@ -40,3 +48,11 @@ jobs:
         run: cmake --build build -j
       - name: Test
         run: ctest --test-dir build --output-on-failure
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ runner.os }}
+          path: |
+            build/**
+            build/spv/**
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- upload build artifacts after test runs in both CMake workflows
- archive binaries and SPIR-V outputs from `build/` and `build/spv`

## Testing
- `PYTHONPATH=. pytest`
- `mypy --ignore-missing-imports src`
- `eslint .` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0285706a4832d82bbfc7794d83719