### PR TITLE
Replace run helper with pytest test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -3,14 +3,18 @@ import numpy as np
 from src.physics.capsule import Capsule
 from src.physics.capsule_voxel_sat import resolve_capsule_world
 
+
 class DummyWorld:
-    def get_block_at_world_position(self, x,y,z): return 1 if int(y)<0 else 0  # ground at y=0
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if int(y) < 0 else 0  # ground at y=0
 
-def run():
-    world=DummyWorld()
-    cap=Capsule(center=np.array([0.0,0.2,0.0],dtype=np.float32), half_height=0.9, radius=0.3)
+
+def test_capsule_ground() -> None:
+    world = DummyWorld()
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
     off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1]>=0.0, (off, cap.center, ground)
-
-if __name__=="__main__":
-    run()
+    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)


### PR DESCRIPTION
## Summary
- replace ad-hoc run helper with `test_capsule_ground`
- drop obsolete `__main__` execution block

## Testing
- `PYTHONPATH=. pytest`
- `flake8 tests/test_capsule_ground.py`
- `mypy tests/test_capsule_ground.py`


------
https://chatgpt.com/codex/tasks/task_e_68a02b023744832dbb991853fdb2b15a