### PR TITLE
chore: install Vulkan deps in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,11 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
       - name: Install deps
-        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake g++
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake g++ libvulkan-dev vulkan-validationlayers-dev glslang-tools libglfw3-dev
+      - name: Set Vulkan env
+        run: echo "VULKAN_SDK=/usr" >> $GITHUB_ENV
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build
@@ -34,6 +38,10 @@ jobs:
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
       - name: Install Ninja and CMake
         run: choco install ninja cmake --yes
+      - name: Install Vulkan SDK and GLFW
+        run: choco install vulkan-sdk glfw --yes
+      - name: Set Vulkan env
+        run: echo "VULKAN_SDK=$Env:VULKAN_SDK" >> $Env:GITHUB_ENV
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Vulkan SDK and GLFW
         run: choco install vulkan-sdk glfw --yes
       - name: Set Vulkan env
-        run: echo "VULKAN_SDK=$Env:VULKAN_SDK" >> $Env:GITHUB_ENV
+        run: echo "VULKAN_SDK=C:\VulkanSDK\latest" >> $Env:GITHUB_ENV
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,5 @@
+export default [
+  {
+    files: ["**/*.{js,ts}"]
+  }
+];


### PR DESCRIPTION
## Summary
- install Vulkan-related packages in Linux CI and export VULKAN_SDK
- install Vulkan SDK and GLFW in Windows CI and export VULKAN_SDK
- add ESLint config so lint step runs

## Testing
- `PYTHONPATH=. pytest`
- `mypy src tests --ignore-missing-imports --explicit-package-bases`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a028537bb0832d8d65383419e448c3