### PR TITLE
chore: add base ESLint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ The compute expects image formats:
 - 2D height: `VK_FORMAT_R32_SFLOAT` (GENERAL)
 - 2D biome: `VK_FORMAT_R8_UINT` (GENERAL)
 - Output 3D blocks: `VK_FORMAT_R16_UINT` (GENERAL)
+
+## Linting
+To check JavaScript or TypeScript sources, run:
+```bash
+npx eslint .
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,2 @@
+export default {
+};


### PR DESCRIPTION
## Summary
- add root `eslint.config.js`
- document ESLint usage in README

## Testing
- `PYTHONPATH=. pytest -q`
- `npx eslint .`
- `mypy --hide-error-context --hide-error-codes --pretty .` *(fails: missing stubs and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a02b43d2a4832d9e5bcfac83103b7b