### PR TITLE
chore: refine workflow artifact paths

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -46,6 +46,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/cache@v3
+      with:
+        path: |
+          build/bin/**
+          build/spv/**
+        key: ${{ runner.os }}-cmake-${{ matrix.c_compiler }}-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -51,7 +51,7 @@ jobs:
         path: |
           build/bin/**
           build/spv/**
-        key: ${{ runner.os }}-cmake-${{ matrix.c_compiler }}-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
 
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
-          path: ~/.cache
+          path: |
+            build/bin/**
+            build/spv/**
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
       - name: Install deps
         run: sudo apt-get update && sudo apt-get install -y ninja-build cmake g++
@@ -30,7 +32,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
-          path: C:\\Users\\runneradmin\\AppData\\Local\\cache
+          path: |
+            build/bin/**
+            build/spv/**
           key: ${{ runner.os }}-cmake-${{ hashFiles('**/CMakeLists.txt') }}
       - name: Install Ninja and CMake
         run: choco install ninja cmake --yes


### PR DESCRIPTION
## Summary
- cache built binaries and shader artifacts in CMake workflows

## Testing
- `PYTHONPATH=. pytest`
- `flake8 .github/workflows`
- `mypy src tests` (fails: Cannot find implementation or library stub for module named ".capsule" and others)
- `npx --yes eslint .` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)


------
https://chatgpt.com/codex/tasks/task_e_68a02b550440832dafb244b5a4bceeb8