### PR TITLE
Rename capsule ground test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -3,14 +3,18 @@ import numpy as np
 from src.physics.capsule import Capsule
 from src.physics.capsule_voxel_sat import resolve_capsule_world
 
+
 class DummyWorld:
-    def get_block_at_world_position(self, x,y,z): return 1 if int(y)<0 else 0  # ground at y=0
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if int(y) < 0 else 0  # ground at y=0
 
-def run():
-    world=DummyWorld()
-    cap=Capsule(center=np.array([0.0,0.2,0.0],dtype=np.float32), half_height=0.9, radius=0.3)
-    off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1]>=0.0, (off, cap.center, ground)
 
-if __name__=="__main__":
-    run()
+def test_capsule_ground():
+    world = DummyWorld()
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
+    offset, grounded = resolve_capsule_world(cap, world)
+    assert grounded and cap.center[1] >= 0.0, (offset, cap.center, grounded)


### PR DESCRIPTION
## Summary
- rename `run` to `test_capsule_ground` and remove manual invocation
- format test module

## Testing
- `PYTHONPATH=. flake8 tests/test_capsule_ground.py`
- `PYTHONPATH=. mypy tests/test_capsule_ground.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a031da28fc832d9efd424ef76e9bd0