### PR TITLE
Recalculate capsule bounds after resolving collisions

### DIFF
--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -60,5 +60,5 @@ def resolve_capsule_world(cap: Capsule, world, max_iters=8):
         mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
         mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
         bb_min = np.floor(mn).astype(int)
-        bb_max = np.floor(mx).astype(int)
+        bb_min, bb_max = compute_capsule_voxel_bounds(cap)
     return total_offset, ground

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -23,15 +23,18 @@ def capsule_box_penetration(cap: Capsule, mn, mx):
     return False, None, 0.0
 
 def resolve_capsule_world(cap: Capsule, world, max_iters=8):
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    bb_min = np.floor(mn).astype(int)
-    bb_max = np.floor(mx).astype(int)
-
     total_offset = np.zeros(3, dtype=np.float32)
     ground = False
     for _ in range(max_iters):
-        max_pen = 0.0; hit_n = None; contact_n = None
+        # Compute voxel bounds based on the capsule's current position.
+        mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+        mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+        bb_min = np.floor(mn).astype(int)
+        bb_max = np.floor(mx).astype(int)
+
+        max_pen = 0.0
+        hit_n = None
+        contact_n = None
         for y in range(bb_min[1]-1, bb_max[1]+2):
             for z in range(bb_min[2]-1, bb_max[2]+2):
                 for x in range(bb_min[0]-1, bb_max[0]+2):
@@ -44,9 +47,18 @@ def resolve_capsule_world(cap: Capsule, world, max_iters=8):
                     if hit and pen > max_pen:
                         max_pen, hit_n = pen, n
                         contact_n = n
-        if max_pen <= 1e-6 or hit_n is None: break
+        if max_pen <= 1e-6 or hit_n is None:
+            break
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if contact_n is not None and contact_n[1] > 0.7: ground = True
+        if contact_n is not None and contact_n[1] > 0.7:
+            ground = True
+
+        # The capsule's center moved, so its voxel bounds must be recalculated.
+        # Recomputing here ensures the next iteration tests the correct region.
+        mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+        mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+        bb_min = np.floor(mn).astype(int)
+        bb_max = np.floor(mx).astype(int)
     return total_offset, ground


### PR DESCRIPTION
## Summary
- update collision resolution to recompute capsule voxel bounds each iteration
- clarify why bounds are recalculated after moving the capsule

## Testing
- `PYTHONPATH=. pytest`
- `ruff check src/physics/capsule_voxel_sat.py`
- `mypy --ignore-missing-imports src/physics/capsule_voxel_sat.py`


------
https://chatgpt.com/codex/tasks/task_e_68a034058d50832d8dbac4c9ace5fbb1