### PR TITLE
Add docstrings and type hints to physics modules

### DIFF
--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,21 +1,40 @@
 
+"""Axis-aligned bounding box helpers for collision tests."""
+
 import numpy as np
 from dataclasses import dataclass
 
 @dataclass
 class AABB:
+    """Simple axis-aligned bounding box.
+
+    Parameters
+    ----------
+    center:
+        Center point of the box ``(x, y, z)`` in world coordinates.
+    half:
+        Half extents ``(hx, hy, hz)`` from the center.
+    """
+
     center: np.ndarray  # (x,y,z) float32
-    half:   np.ndarray  # (hx,hy,hz) float32
+    half: np.ndarray  # (hx,hy,hz) float32
 
     @property
-    def min(self): return self.center - self.half
+    def min(self) -> np.ndarray:
+        """Minimum corner of the box."""
+        return self.center - self.half
+
     @property
-    def max(self): return self.center + self.half
+    def max(self) -> np.ndarray:
+        """Maximum corner of the box."""
+        return self.center + self.half
 
     def moved(self, delta: np.ndarray) -> "AABB":
+        """Return a new box offset by ``delta``."""
         return AABB(self.center + delta, self.half)
 
     def overlap_aabb(self, other: "AABB") -> bool:
+        """Check whether this box overlaps ``other``."""
         return not (
             self.max[0] <= other.min[0] or self.min[0] >= other.max[0] or
             self.max[1] <= other.min[1] or self.min[1] >= other.max[1] or

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,17 +1,33 @@
 
+"""Definition of a vertical capsule shape used for collision queries."""
+
 import numpy as np
 from dataclasses import dataclass
 
 @dataclass
 class Capsule:
+    """Vertical capsule represented by a center point and radius.
+
+    Parameters
+    ----------
+    center:
+        Capsule midpoint ``(x, y, z)``.
+    half_height:
+        Distance from the center to the center of each spherical cap.
+    radius:
+        Radius of the capsule.
+    """
+
     center: np.ndarray
     half_height: float
     radius: float
 
     @property
-    def seg_a(self):  # top cap center
+    def seg_a(self) -> np.ndarray:  # top cap center
+        """Center of the top spherical cap."""
         return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
 
     @property
-    def seg_b(self):  # bottom cap center
+    def seg_b(self) -> np.ndarray:  # bottom cap center
+        """Center of the bottom spherical cap."""
         return self.center - np.array([0, self.half_height, 0], dtype=np.float32)

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,40 +1,62 @@
 
+"""Collision detection between a capsule and a voxel grid using SAT."""
+
+from typing import Any, Optional, Tuple
+
 import numpy as np
 from .capsule import Capsule
 
-def closest_point_on_aabb(p, mn, mx):
+
+def closest_point_on_aabb(p: np.ndarray, mn: np.ndarray, mx: np.ndarray) -> np.ndarray:
+    """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
     return np.minimum(np.maximum(p, mn), mx)
 
-def closest_point_on_segment(p, a, b):
+
+def closest_point_on_segment(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Return the closest point on the segment ``ab`` to ``p``."""
     ab = b - a
     t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
     return a + np.clip(t, 0.0, 1.0) * ab
 
-def capsule_box_penetration(cap: Capsule, mn, mx):
+
+def capsule_box_penetration(
+    cap: Capsule, mn: np.ndarray, mx: np.ndarray
+) -> Tuple[bool, Optional[np.ndarray], float]:
+    """Compute penetration of ``cap`` against an axis-aligned box."""
     box_center = (mn + mx) * 0.5
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
     v = q_seg - q_box
     dist = np.linalg.norm(v)
-    pen = cap.radius - dist
+    pen = float(cap.radius - dist)
     if pen > 0.0:
-        n = (v / (dist + 1e-9)) if dist > 1e-8 else np.array([0,1,0], dtype=np.float32)
+        n = (v / (dist + 1e-9)) if dist > 1e-8 else np.array([0, 1, 0], dtype=np.float32)
         return True, n, pen
     return False, None, 0.0
 
-def resolve_capsule_world(cap: Capsule, world, max_iters=8):
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+
+def resolve_capsule_world(
+    cap: Capsule, world: Any, max_iters: int = 8
+) -> Tuple[np.ndarray, bool]:
+    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
+    mn = cap.center - np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
+    mx = cap.center + np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
     bb_min = np.floor(mn).astype(int)
     bb_max = np.floor(mx).astype(int)
 
     total_offset = np.zeros(3, dtype=np.float32)
     ground = False
     for _ in range(max_iters):
-        max_pen = 0.0; hit_n = None; contact_n = None
-        for y in range(bb_min[1]-1, bb_max[1]+2):
-            for z in range(bb_min[2]-1, bb_max[2]+2):
-                for x in range(bb_min[0]-1, bb_max[0]+2):
+        max_pen = 0.0
+        hit_n: Optional[np.ndarray] = None
+        contact_n: Optional[np.ndarray] = None
+        for y in range(bb_min[1] - 1, bb_max[1] + 2):
+            for z in range(bb_min[2] - 1, bb_max[2] + 2):
+                for x in range(bb_min[0] - 1, bb_max[0] + 2):
                     bt = world.get_block_at_world_position(float(x), float(y), float(z))
                     if bt == 0:
                         continue
@@ -44,9 +66,11 @@ def resolve_capsule_world(cap: Capsule, world, max_iters=8):
                     if hit and pen > max_pen:
                         max_pen, hit_n = pen, n
                         contact_n = n
-        if max_pen <= 1e-6 or hit_n is None: break
+        if max_pen <= 1e-6 or hit_n is None:
+            break
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if contact_n is not None and contact_n[1] > 0.7: ground = True
+        if contact_n is not None and contact_n[1] > 0.7:
+            ground = True
     return total_offset, ground

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -28,7 +28,7 @@ def capsule_box_penetration(
     q_box = closest_point_on_aabb(q_seg, mn, mx)
     v = q_seg - q_box
     dist = np.linalg.norm(v)
-    pen = float(cap.radius - dist)
+    pen = cap.radius - dist
     if pen > 0.0:
         n = (v / (dist + 1e-9)) if dist > 1e-8 else np.array([0, 1, 0], dtype=np.float32)
         return True, n, pen

--- a/src/physics/player_controller.py
+++ b/src/physics/player_controller.py
@@ -1,14 +1,28 @@
 
+"""AABB-based player controller for movement inside a voxel world."""
+
+from typing import Any, Dict, Tuple
+
 import numpy as np
 from .aabb import AABB
 from .voxel_solid import is_solid
 
 class PlayerController:
+    """Axis-aligned bounding box player controller.
+
+    Parameters
+    ----------
+    world_manager:
+        World accessor providing ``get_block_at_world_position``.
+    spawn:
+        Initial spawn position of the player.
     """
-    Capsule-approximated as AABB (0.6 x 1.8) with swept, axis-separated collision against the voxel grid.
-    Integrates gravity, jump, step-up, and ground detection.
-    """
-    def __init__(self, world_manager, spawn=np.array([0.0, 100.0, 0.0], dtype=np.float32)):
+
+    def __init__(
+        self,
+        world_manager: Any,
+        spawn: np.ndarray = np.array([0.0, 100.0, 0.0], dtype=np.float32),
+    ) -> None:
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
@@ -21,12 +35,23 @@ class PlayerController:
         self.jump_speed = 9.5
         self.step_height = 0.5
         self.on_ground = False
-        self.input = {"f":0,"b":0,"l":0,"r":0,"up":0,"down":0,"jump":0,"sprint":0}
+        self.input: Dict[str, int] = {
+            "f": 0,
+            "b": 0,
+            "l": 0,
+            "r": 0,
+            "up": 0,
+            "down": 0,
+            "jump": 0,
+            "sprint": 0,
+        }
 
-    def set_input(self, keymap: dict):
-        self.input.update({k:int(bool(v)) for k,v in keymap.items() if k in self.input})
+    def set_input(self, keymap: Dict[str, int]) -> None:
+        self.input.update({k: int(bool(v)) for k, v in keymap.items() if k in self.input})
 
-    def update(self, dt: float, camera_forward: np.ndarray, camera_right: np.ndarray):
+    def update(
+        self, dt: float, camera_forward: np.ndarray, camera_right: np.ndarray
+    ) -> None:
         wish = (camera_forward * (self.input["f"]-self.input["b"]) +
                 camera_right   * (self.input["r"]-self.input["l"]))
         wish[1] = 0.0
@@ -49,7 +74,7 @@ class PlayerController:
             if self._can_occupy(lifted):
                 self.pos = lifted; self._move_and_collide(dt)
 
-    def _move_and_collide(self, dt: float):
+    def _move_and_collide(self, dt: float) -> None:
         delta = self.vel * dt
         self.pos, hit_x = self._sweep_axis(self.pos, 0, delta[0])
         self.pos, hit_z = self._sweep_axis(self.pos, 2, delta[2])
@@ -62,8 +87,10 @@ class PlayerController:
         else:
             self.on_ground = False
 
-    def _sweep_axis(self, pos, axis, delta):
-        step = np.sign(delta); remaining = abs(delta); hit=False
+    def _sweep_axis(
+        self, pos: np.ndarray, axis: int, delta: float
+    ) -> Tuple[np.ndarray, bool]:
+        step = np.sign(delta); remaining = abs(delta); hit = False
         while remaining > 1e-6:
             advance = min(remaining, 0.1)
             trial = pos.copy(); trial[axis] += step*advance
@@ -76,10 +103,10 @@ class PlayerController:
                     trial_mid = pos.copy(); trial_mid[axis] += step*mid
                     if self._can_occupy(trial_mid): lo = mid
                     else: hi = mid
-                pos[axis] += step*lo; hit=True; break
+                pos[axis] += step*lo; hit = True; break
         return pos, hit
 
-    def _can_occupy(self, center):
+    def _can_occupy(self, center: np.ndarray) -> bool:
         aabb = AABB(center=center, half=self.aabb.half)
         mn = np.floor(aabb.min).astype(int); mx = np.floor(aabb.max).astype(int)
         for y in range(mn[1], mx[1]+1):

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -1,10 +1,41 @@
 
+"""Capsule-based player controller using SAT collision resolution."""
+
+from typing import Any, Dict
+
 import numpy as np
 from .capsule import Capsule
 from .capsule_voxel_sat import resolve_capsule_world
 
 class PlayerControllerCapsule:
-    def __init__(self, world_manager, spawn, step_height=0.5, gravity=28.0, max_speed=11.0, jump_speed=9.5):
+    """Capsule-based player controller.
+
+    Parameters
+    ----------
+    world_manager:
+        World accessor providing ``get_block_at_world_position``.
+    spawn:
+        Initial spawn position of the player.
+    step_height, gravity, max_speed, jump_speed:
+        Tuning parameters for character movement.
+
+    Example
+    -------
+    >>> pc = PlayerControllerCapsule(world, np.array([0.0, 1.0, 0.0], dtype=np.float32))
+    >>> forward = np.array([0.0, 0.0, 1.0], dtype=np.float32)
+    >>> right = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    >>> pc.update(0.016, forward, right)
+    """
+
+    def __init__(
+        self,
+        world_manager: Any,
+        spawn: np.ndarray,
+        step_height: float = 0.5,
+        gravity: float = 28.0,
+        max_speed: float = 11.0,
+        jump_speed: float = 9.5,
+    ) -> None:
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
@@ -15,13 +46,15 @@ class PlayerControllerCapsule:
         self.max_speed = max_speed
         self.jump_speed = jump_speed
         self.on_ground = False
-        self.input = {"f":0,"b":0,"l":0,"r":0,"jump":0,"sprint":0}
+        self.input: Dict[str, int] = {"f":0,"b":0,"l":0,"r":0,"jump":0,"sprint":0}
 
-    def set_input(self, m): self.input.update(m)
+    def set_input(self, m: Dict[str, int]) -> None:
+        self.input.update(m)
 
-    def _capsule(self): return Capsule(self.pos.copy(), self.half_h, self.radius)
+    def _capsule(self) -> Capsule:
+        return Capsule(self.pos.copy(), self.half_h, self.radius)
 
-    def update(self, dt, forward, right):
+    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
         wish = (forward*(self.input["f"]-self.input["b"]) + right*(self.input["r"]-self.input["l"])); wish[1]=0
         n=np.linalg.norm(wish);  wish = wish/n if n>1e-6 else wish
         target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,12 +1,18 @@
 
+"""Utilities to query whether a voxel block type is solid."""
+
 from typing import Dict
+
 # Adapt this to your engine's block registry
 class BlockType:
+    """Enumeration of built-in block types."""
     AIR = 0
 
 BLOCK_PROPERTIES: Dict[int, dict] = {}
 
+
 def is_solid(block_type: int) -> bool:
+    """Return ``True`` if ``block_type`` should be considered solid."""
     try:
         props = BLOCK_PROPERTIES.get(block_type, {})
         return bool(props.get("solid", block_type != BlockType.AIR))


### PR DESCRIPTION
## Summary
- document axis-aligned box and capsule collision helpers
- type annotate physics controllers and helper functions
- clarify PlayerControllerCapsule usage with example

## Testing
- `PYTHONPATH=. pytest`
- `pyflakes src/physics tests`
- `mypy --ignore-missing-imports --explicit-package-bases src/physics tests/test_capsule_ground.py`


------
https://chatgpt.com/codex/tasks/task_e_68a034078bf4832d96f8933309b165f2