### PR TITLE
Add Python deps and ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+/** @type {import('eslint').Linter.FlatConfig[]} */
+module.exports = [
+  {
+    ignores: ["**/build/**"]
+  },
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"] ,
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module"
+    },
+    rules: {
+      "no-unused-vars": "warn",
+      "semi": ["error", "always"]
+    }
+  }
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ module.exports = [
     ignores: ["**/build/**"]
   },
   {
-    files: ["**/*.{js,jsx,ts,tsx}"] ,
+    files: ["**/*.{js,jsx,ts,tsx}"],
     languageOptions: {
       ecmaVersion: 2020,
       sourceType: "module"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+zstandard
+lz4


### PR DESCRIPTION
## Summary
- add numpy, zstandard, and lz4 to Python requirements
- introduce root ESLint configuration

## Testing
- `PYTHONPATH=. pytest`
- `PYTHONPATH=. mypy --namespace-packages --explicit-package-bases --ignore-missing-imports src tests`
- `npx eslint . --ext .js,.jsx,.ts,.tsx --no-error-on-unmatched-pattern`


------
https://chatgpt.com/codex/tasks/task_e_68a0347906cc832db6c651b430f00942