### PR TITLE
docs: add ChunkStore and player controller guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ The compute expects image formats:
 - 2D height: `VK_FORMAT_R32_SFLOAT` (GENERAL)
 - 2D biome: `VK_FORMAT_R8_UINT` (GENERAL)
 - Output 3D blocks: `VK_FORMAT_R16_UINT` (GENERAL)
+
+## Documentation
+
+- [ChunkStore and Player Controller Capsule](docs/chunkstore_player_controller.md)

--- a/docs/chunkstore_player_controller.md
+++ b/docs/chunkstore_player_controller.md
@@ -1,0 +1,56 @@
+# ChunkStore and Player Controller Capsule
+
+This guide covers saving voxel chunks with `ChunkStore` and updating a capsule-based player controller.
+
+## ChunkStore
+
+`ChunkStore` manages compressed voxel data on disk. The implementation in [src/world/persistence.py](../src/world/persistence.py) supports `zstd`, `lz4`, or no compression. Choose a codec at construction time:
+
+```python
+from world.persistence import ChunkStore  # src/world/persistence.py
+
+store = ChunkStore(root="world_save", codec="zstd", use_rle=True)
+```
+
+Saving chunks can be scheduled asynchronously and flushed later:
+
+```python
+store.save_async(chunk)
+store.wait_all()  # ensure writes complete
+```
+
+Chunks are loaded on demand by coordinate:
+
+```python
+loaded = store.load_chunk(cx, cz)
+if loaded:
+    voxels = loaded["voxels"]
+```
+
+To use a different codec or disable run-length encoding:
+
+```python
+store = ChunkStore(root="world_save", codec="lz4", use_rle=False)
+```
+
+## PlayerControllerCapsule
+
+`PlayerControllerCapsule` from [src/physics/player_controller_capsule.py](../src/physics/player_controller_capsule.py) updates position and velocity for a capsule-shaped player.
+
+```python
+from physics.player_controller_capsule import PlayerControllerCapsule  # src/physics/player_controller_capsule.py
+
+controller = PlayerControllerCapsule(world_manager, spawn)
+```
+
+Inside the game loop, feed inputs and call `update`:
+
+```python
+while running:
+    controller.set_input(read_inputs())
+    controller.update(dt, forward, right)
+    if controller.on_ground:
+        ...
+```
+
+The controller applies acceleration, gravity, optional jumping, and step handling each frame.


### PR DESCRIPTION
## Summary
- document setting up ChunkStore and saving/loading chunks
- show basic PlayerControllerCapsule usage in a game loop
- link new guide from README
- reference source modules and provide codec and loop examples

## Testing
- `PYTHONPATH=. pytest -q`
- `ruff check README.md docs/chunkstore_player_controller.md`
- `mypy --ignore-missing-imports src/world/persistence.py src/physics/player_controller_capsule.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0340fda28832db7b3a3d72fe70c75