### PR TITLE
chore: add common ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.venv/
+env/
+.mypy_cache/
+.nox/
+.coverage
+coverage.xml
+.eggs/
+*.egg
+Pipfile.lock
+.DS_Store
+__pycache__/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = .
+testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
## Summary
- ignore virtual environments, coverage artifacts, egg builds, and other local files
- configure pytest to include project root in module search path

## Testing
- `pytest -q` *(no tests ran)*
- `flake8 .` *(fails: multiple style issues)*
- `mypy .` *(fails: missing imports and stubs)*
- `npx eslint .` *(fails: missing ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a0347690e8832da3a071dbc179c529