### PR TITLE
Rename and improve capsule-ground collision test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -3,14 +3,18 @@ import numpy as np
 from src.physics.capsule import Capsule
 from src.physics.capsule_voxel_sat import resolve_capsule_world
 
+
 class DummyWorld:
-    def get_block_at_world_position(self, x,y,z): return 1 if int(y)<0 else 0  # ground at y=0
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if int(y) < 0 else 0  # ground at y=0
 
-def run():
-    world=DummyWorld()
-    cap=Capsule(center=np.array([0.0,0.2,0.0],dtype=np.float32), half_height=0.9, radius=0.3)
+
+def test_capsule_ground_collision():
+    world = DummyWorld()
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
     off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1]>=0.0, (off, cap.center, ground)
-
-if __name__=="__main__":
-    run()
+    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)


### PR DESCRIPTION
## Summary
- rename test runner to `test_capsule_ground_collision`
- expand DummyWorld method and remove script entry point

## Testing
- `flake8 tests/test_capsule_ground.py`
- `mypy tests/test_capsule_ground.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a03cddbad8832db08dcd61a3bcdccf