### PR TITLE
Refactor physics modules for lint compliance

### DIFF
--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,16 +1,19 @@
-
 import numpy as np
 from dataclasses import dataclass
+
 
 @dataclass
 class AABB:
     center: np.ndarray  # (x,y,z) float32
-    half:   np.ndarray  # (hx,hy,hz) float32
+    half: np.ndarray  # (hx,hy,hz) float32
 
     @property
-    def min(self): return self.center - self.half
+    def min(self):
+        return self.center - self.half
+
     @property
-    def max(self): return self.center + self.half
+    def max(self):
+        return self.center + self.half
 
     def moved(self, delta: np.ndarray) -> "AABB":
         return AABB(self.center + delta, self.half)

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -2,6 +2,7 @@
 import numpy as np
 from dataclasses import dataclass
 
+
 @dataclass
 class Capsule:
     center: np.ndarray
@@ -10,8 +11,12 @@ class Capsule:
 
     @property
     def seg_a(self):  # top cap center
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
+        return self.center + np.array(
+            [0, self.half_height, 0], dtype=np.float32
+        )
 
     @property
     def seg_b(self):  # bottom cap center
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
+        return self.center - np.array(
+            [0, self.half_height, 0], dtype=np.float32
+        )

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -2,13 +2,16 @@
 import numpy as np
 from .capsule import Capsule
 
+
 def closest_point_on_aabb(p, mn, mx):
     return np.minimum(np.maximum(p, mn), mx)
+
 
 def closest_point_on_segment(p, a, b):
     ab = b - a
     t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
     return a + np.clip(t, 0.0, 1.0) * ab
+
 
 def capsule_box_penetration(cap: Capsule, mn, mx):
     box_center = (mn + mx) * 0.5
@@ -18,24 +21,39 @@ def capsule_box_penetration(cap: Capsule, mn, mx):
     dist = np.linalg.norm(v)
     pen = cap.radius - dist
     if pen > 0.0:
-        n = (v / (dist + 1e-9)) if dist > 1e-8 else np.array([0,1,0], dtype=np.float32)
+        n = (
+            (v / (dist + 1e-9))
+            if dist > 1e-8
+            else np.array([0, 1, 0], dtype=np.float32)
+        )
         return True, n, pen
     return False, None, 0.0
 
+
 def resolve_capsule_world(cap: Capsule, world, max_iters=8):
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+    mn = cap.center - np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
+    )
+    mx = cap.center + np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
+    )
     bb_min = np.floor(mn).astype(int)
     bb_max = np.floor(mx).astype(int)
 
     total_offset = np.zeros(3, dtype=np.float32)
     ground = False
     for _ in range(max_iters):
-        max_pen = 0.0; hit_n = None; contact_n = None
-        for y in range(bb_min[1]-1, bb_max[1]+2):
-            for z in range(bb_min[2]-1, bb_max[2]+2):
-                for x in range(bb_min[0]-1, bb_max[0]+2):
-                    bt = world.get_block_at_world_position(float(x), float(y), float(z))
+        max_pen = 0.0
+        hit_n = None
+        contact_n = None
+        for y in range(bb_min[1] - 1, bb_max[1] + 2):
+            for z in range(bb_min[2] - 1, bb_max[2] + 2):
+                for x in range(bb_min[0] - 1, bb_max[0] + 2):
+                    bt = world.get_block_at_world_position(
+                        float(x), float(y), float(z)
+                    )
                     if bt == 0:
                         continue
                     mnv = np.array([x, y, z], dtype=np.float32)
@@ -44,9 +62,11 @@ def resolve_capsule_world(cap: Capsule, world, max_iters=8):
                     if hit and pen > max_pen:
                         max_pen, hit_n = pen, n
                         contact_n = n
-        if max_pen <= 1e-6 or hit_n is None: break
+        if max_pen <= 1e-6 or hit_n is None:
+            break
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if contact_n is not None and contact_n[1] > 0.7: ground = True
+        if contact_n is not None and contact_n[1] > 0.7:
+            ground = True
     return total_offset, ground

--- a/src/physics/player_controller.py
+++ b/src/physics/player_controller.py
@@ -1,18 +1,24 @@
-
 import numpy as np
+
 from .aabb import AABB
 from .voxel_solid import is_solid
 
+
 class PlayerController:
-    """
-    Capsule-approximated as AABB (0.6 x 1.8) with swept, axis-separated collision against the voxel grid.
-    Integrates gravity, jump, step-up, and ground detection.
-    """
-    def __init__(self, world_manager, spawn=np.array([0.0, 100.0, 0.0], dtype=np.float32)):
+    """Simple player controller using an AABB capsule approximation."""
+
+    def __init__(
+        self,
+        world_manager,
+        spawn=np.array([0.0, 100.0, 0.0], dtype=np.float32),
+    ):
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
-        self.aabb = AABB(center=self.pos, half=np.array([0.3, 0.9, 0.3], dtype=np.float32))
+        self.aabb = AABB(
+            center=self.pos,
+            half=np.array([0.3, 0.9, 0.3], dtype=np.float32),
+        )
         self.gravity = 28.0
         self.max_speed = 11.0
         self.accel = 50.0
@@ -21,78 +27,126 @@ class PlayerController:
         self.jump_speed = 9.5
         self.step_height = 0.5
         self.on_ground = False
-        self.input = {"f":0,"b":0,"l":0,"r":0,"up":0,"down":0,"jump":0,"sprint":0}
+        self.input = {
+            "f": 0,
+            "b": 0,
+            "l": 0,
+            "r": 0,
+            "up": 0,
+            "down": 0,
+            "jump": 0,
+            "sprint": 0,
+        }
 
     def set_input(self, keymap: dict):
-        self.input.update({k:int(bool(v)) for k,v in keymap.items() if k in self.input})
+        self.input.update(
+            {k: int(bool(v)) for k, v in keymap.items() if k in self.input}
+        )
 
-    def update(self, dt: float, camera_forward: np.ndarray, camera_right: np.ndarray):
-        wish = (camera_forward * (self.input["f"]-self.input["b"]) +
-                camera_right   * (self.input["r"]-self.input["l"]))
+    def update(
+        self,
+        dt: float,
+        camera_forward: np.ndarray,
+        camera_right: np.ndarray,
+    ):
+        wish = (
+            camera_forward * (self.input["f"] - self.input["b"])
+            + camera_right * (self.input["r"] - self.input["l"])
+        )
         wish[1] = 0.0
         wl = np.linalg.norm(wish)
-        if wl > 1e-6: wish /= wl
+        if wl > 1e-6:
+            wish /= wl
         target_speed = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
         accel = self.accel if self.on_ground else self.air_accel
-        hv = self.vel.copy(); hv[1]=0
-        self.vel += (wish * target_speed - hv) * min(1.0, accel*dt)
+        hv = self.vel.copy()
+        hv[1] = 0
+        self.vel += (wish * target_speed - hv) * min(1.0, accel * dt)
         if self.on_ground and wl < 1e-6:
-            self.vel[0] *= max(0.0, 1.0 - self.friction*dt)
-            self.vel[2] *= max(0.0, 1.0 - self.friction*dt)
-        self.vel[1] -= self.gravity*dt
+            self.vel[0] *= max(0.0, 1.0 - self.friction * dt)
+            self.vel[2] *= max(0.0, 1.0 - self.friction * dt)
+        self.vel[1] -= self.gravity * dt
         if self.on_ground and self.input["jump"]:
-            self.vel[1] = self.jump_speed; self.on_ground = False
+            self.vel[1] = self.jump_speed
+            self.on_ground = False
         pos_before = self.pos.copy()
         self._move_and_collide(dt)
-        if np.allclose(self.pos, pos_before, atol=1e-5) and (self.input["f"] or self.input["l"] or self.input["r"] or self.input["b"]):
-            lifted = self.pos.copy(); lifted[1] += self.step_height
+        if np.allclose(self.pos, pos_before, atol=1e-5) and (
+            self.input["f"]
+            or self.input["l"]
+            or self.input["r"]
+            or self.input["b"]
+        ):
+            lifted = self.pos.copy()
+            lifted[1] += self.step_height
             if self._can_occupy(lifted):
-                self.pos = lifted; self._move_and_collide(dt)
+                self.pos = lifted
+                self._move_and_collide(dt)
 
     def _move_and_collide(self, dt: float):
         delta = self.vel * dt
         self.pos, hit_x = self._sweep_axis(self.pos, 0, delta[0])
         self.pos, hit_z = self._sweep_axis(self.pos, 2, delta[2])
         self.pos, hit_y = self._sweep_axis(self.pos, 1, delta[1])
-        if hit_x: self.vel[0] = 0.0
-        if hit_z: self.vel[2] = 0.0
+        if hit_x:
+            self.vel[0] = 0.0
+        if hit_z:
+            self.vel[2] = 0.0
         if hit_y:
-            if delta[1] < 0: self.on_ground = True
-            if delta[1] > 0 and self.vel[1] > 0: self.vel[1] = 0.0
+            if delta[1] < 0:
+                self.on_ground = True
+            if delta[1] > 0 and self.vel[1] > 0:
+                self.vel[1] = 0.0
         else:
             self.on_ground = False
 
     def _sweep_axis(self, pos, axis, delta):
-        step = np.sign(delta); remaining = abs(delta); hit=False
+        step = np.sign(delta)
+        remaining = abs(delta)
+        hit = False
         while remaining > 1e-6:
             advance = min(remaining, 0.1)
-            trial = pos.copy(); trial[axis] += step*advance
+            trial = pos.copy()
+            trial[axis] += step * advance
             if self._can_occupy(trial):
-                pos = trial; remaining -= advance
+                pos = trial
+                remaining -= advance
             else:
                 hi, lo = advance, 0.0
                 for _ in range(8):
-                    mid = 0.5*(hi+lo)
-                    trial_mid = pos.copy(); trial_mid[axis] += step*mid
-                    if self._can_occupy(trial_mid): lo = mid
-                    else: hi = mid
-                pos[axis] += step*lo; hit=True; break
+                    mid = 0.5 * (hi + lo)
+                    trial_mid = pos.copy()
+                    trial_mid[axis] += step * mid
+                    if self._can_occupy(trial_mid):
+                        lo = mid
+                    else:
+                        hi = mid
+                pos[axis] += step * lo
+                hit = True
+                break
         return pos, hit
 
     def _can_occupy(self, center):
         aabb = AABB(center=center, half=self.aabb.half)
-        mn = np.floor(aabb.min).astype(int); mx = np.floor(aabb.max).astype(int)
-        for y in range(mn[1], mx[1]+1):
-            for z in range(mn[2], mx[2]+1):
-                for x in range(mn[0], mx[0]+1):
-                    bt = self.world.get_block_at_world_position(float(x), float(y), float(z))
+        mn = np.floor(aabb.min).astype(int)
+        mx = np.floor(aabb.max).astype(int)
+        for y in range(mn[1], mx[1] + 1):
+            for z in range(mn[2], mx[2] + 1):
+                for x in range(mn[0], mx[0] + 1):
+                    bt = self.world.get_block_at_world_position(
+                        float(x), float(y), float(z)
+                    )
                     if is_solid(bt):
-                        if self._aabb_voxel_overlap(aabb, x,y,z): return False
+                        if self._aabb_voxel_overlap(aabb, x, y, z):
+                            return False
         return True
 
     @staticmethod
-    def _aabb_voxel_overlap(aabb: AABB, x:int, y:int, z:int) -> bool:
-        if aabb.max[0] <= x or aabb.min[0] >= x+1: return False
-        if aabb.max[1] <= y or aabb.min[1] >= y+1: return False
-        if aabb.max[2] <= z or aabb.min[2] >= z+1: return False
+    def _aabb_voxel_overlap(aabb: AABB, x: int, y: int, z: int) -> bool:
+        if aabb.max[0] <= x or aabb.min[0] >= x + 1:
+            return False
+        if aabb.max[1] <= y or aabb.min[1] >= y + 1:
+            return False
+        if aabb.max[2] <= z or aabb.min[2] >= z + 1:
+            return False
         return True

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -44,7 +44,7 @@ class PlayerControllerCapsule:
             forward * (self.input["f"] - self.input["b"])
             + right * (self.input["r"] - self.input["l"])
         )
-        wish[1] = 0.0
+        wish[1] = 0
         n = np.linalg.norm(wish)
         wish = wish / n if n > 1e-6 else wish
         target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -1,10 +1,19 @@
-
 import numpy as np
+
 from .capsule import Capsule
 from .capsule_voxel_sat import resolve_capsule_world
 
+
 class PlayerControllerCapsule:
-    def __init__(self, world_manager, spawn, step_height=0.5, gravity=28.0, max_speed=11.0, jump_speed=9.5):
+    def __init__(
+        self,
+        world_manager,
+        spawn,
+        step_height=0.5,
+        gravity=28.0,
+        max_speed=11.0,
+        jump_speed=9.5,
+    ):
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
@@ -15,31 +24,55 @@ class PlayerControllerCapsule:
         self.max_speed = max_speed
         self.jump_speed = jump_speed
         self.on_ground = False
-        self.input = {"f":0,"b":0,"l":0,"r":0,"jump":0,"sprint":0}
+        self.input = {
+            "f": 0,
+            "b": 0,
+            "l": 0,
+            "r": 0,
+            "jump": 0,
+            "sprint": 0,
+        }
 
-    def set_input(self, m): self.input.update(m)
+    def set_input(self, mapping):
+        self.input.update(mapping)
 
-    def _capsule(self): return Capsule(self.pos.copy(), self.half_h, self.radius)
+    def _capsule(self):
+        return Capsule(self.pos.copy(), self.half_h, self.radius)
 
     def update(self, dt, forward, right):
-        wish = (forward*(self.input["f"]-self.input["b"]) + right*(self.input["r"]-self.input["l"])); wish[1]=0
-        n=np.linalg.norm(wish);  wish = wish/n if n>1e-6 else wish
+        wish = (
+            forward * (self.input["f"] - self.input["b"])
+            + right * (self.input["r"] - self.input["l"])
+        )
+        wish[1] = 0.0
+        n = np.linalg.norm(wish)
+        wish = wish / n if n > 1e-6 else wish
         target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
-        hv = self.vel.copy(); hv[1]=0
-        self.vel += (wish*target - hv) * min(1.0, (50.0 if self.on_ground else 10.0)*dt)
+        hv = self.vel.copy()
+        hv[1] = 0
+        self.vel += (wish * target - hv) * min(
+            1.0, (50.0 if self.on_ground else 10.0) * dt
+        )
 
-        self.vel[1] -= self.g*dt
+        self.vel[1] -= self.g * dt
         if self.on_ground and self.input["jump"]:
-            self.vel[1] = self.jump_speed; self.on_ground = False
+            self.vel[1] = self.jump_speed
+            self.on_ground = False
 
-        self.pos += self.vel*dt
+        self.pos += self.vel * dt
         cap = self._capsule()
         off, ground = resolve_capsule_world(cap, self.world)
-        if np.allclose(off, 0.0, atol=1e-6) and (self.input["f"] or self.input["l"] or self.input["r"] or self.input["b"]):
+        if np.allclose(off, 0.0, atol=1e-6) and (
+            self.input["f"]
+            or self.input["l"]
+            or self.input["r"]
+            or self.input["b"]
+        ):
             cap.center[1] += self.step_height
             off2, ground2 = resolve_capsule_world(cap, self.world)
             if not np.allclose(off2, 0.0, atol=1e-6):
                 ground = ground or ground2
         self.pos = cap.center
         self.on_ground = ground
-        if ground and self.vel[1] < 0: self.vel[1] = 0.0
+        if ground and self.vel[1] < 0:
+            self.vel[1] = 0.0

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,10 +1,13 @@
-
 from typing import Dict
+
+
 # Adapt this to your engine's block registry
 class BlockType:
     AIR = 0
 
+
 BLOCK_PROPERTIES: Dict[int, dict] = {}
+
 
 def is_solid(block_type: int) -> bool:
     try:

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -1,16 +1,23 @@
-
 import numpy as np
 from src.physics.capsule import Capsule
 from src.physics.capsule_voxel_sat import resolve_capsule_world
 
+
 class DummyWorld:
-    def get_block_at_world_position(self, x,y,z): return 1 if int(y)<0 else 0  # ground at y=0
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if int(y) < 0 else 0  # ground at y=0
+
 
 def run():
-    world=DummyWorld()
-    cap=Capsule(center=np.array([0.0,0.2,0.0],dtype=np.float32), half_height=0.9, radius=0.3)
+    world = DummyWorld()
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
     off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1]>=0.0, (off, cap.center, ground)
+    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     run()


### PR DESCRIPTION
## Summary
- split compound statements in capsule collision resolution for clarity
- add missing newlines and reformat physics utilities to satisfy flake8
- tidy capsule ground test helper and formatting

## Testing
- `flake8 src/physics tests`
- `mypy --ignore-missing-imports --explicit-package-bases src/physics tests`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a03cded1a0832dbf35697293e7a942