### PR TITLE
Convert capsule-ground test to pytest

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -1,16 +1,19 @@
-
 import numpy as np
 from src.physics.capsule import Capsule
 from src.physics.capsule_voxel_sat import resolve_capsule_world
 
+
 class DummyWorld:
-    def get_block_at_world_position(self, x,y,z): return 1 if int(y)<0 else 0  # ground at y=0
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if int(y) < 0 else 0  # ground at y=0
 
-def run():
-    world=DummyWorld()
-    cap=Capsule(center=np.array([0.0,0.2,0.0],dtype=np.float32), half_height=0.9, radius=0.3)
+
+def test_capsule_ground_collision():
+    world = DummyWorld()
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
     off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1]>=0.0, (off, cap.center, ground)
-
-if __name__=="__main__":
-    run()
+    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)


### PR DESCRIPTION
## Summary
- refactor capsule-ground check into `test_capsule_ground_collision`
- drop manual `__main__` execution
- format test for flake8 compliance

## Testing
- `PYTHONPATH=. pytest`
- `flake8 tests/test_capsule_ground.py`
- `mypy tests/test_capsule_ground.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03cf6a758832d8baf76d6476c28a7