### PR TITLE
Add missing modules for mypy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+lz4
+numpy
+zstandard

--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -1,0 +1,1 @@
+"""Physics package."""

--- a/src/world/__init__.py
+++ b/src/world/__init__.py
@@ -1,0 +1,1 @@
+"""World package."""

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -11,7 +11,7 @@ try:
 except Exception:
     has_zstd=False
 try:
-    import lz4.frame as lz4f
+    import lz4.frame as lz4f  # type: ignore[import]
     has_lz4=True
 except Exception:
     has_lz4=False


### PR DESCRIPTION
## Summary
- declare physics and world as Python packages so mypy can resolve internal modules
- add runtime dependencies and ignore untyped `lz4` import

## Testing
- `mypy src`
- `PYTHONPATH=. pytest`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_68a043f76b60832da0bd79f63cff97bb