### PR TITLE
chore: ignore non-JS directories in ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,3 @@ shaders/
 shaders_vk/
 tools/
 tests/
-scripts/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,11 @@
+assets/
+build_ci_sanity/
+cmake/
+docs/
+shaders/
+shaders_vk/
+tools/
+tests/
+src/
+apps/
+scripts/

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,6 +6,5 @@ shaders/
 shaders_vk/
 tools/
 tests/
-src/
 apps/
 scripts/

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,4 @@ shaders/
 shaders_vk/
 tools/
 tests/
-apps/
 scripts/


### PR DESCRIPTION
## Summary
- add `.eslintignore` to exclude assets, build_ci_sanity, and other non-JS directories from linting

## Testing
- `PYTHONPATH=. pytest`
- `MYPYPATH=. mypy tests/test_capsule_ground.py`
- `npx eslint .`
- `npx eslint assets`


------
https://chatgpt.com/codex/tasks/task_e_68a043f8fbe4832dbc426dc2a5d14ef4