### PR TITLE
Add root setting to ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "root": true,
+  "env": {
+    "node": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "script"
+  }
+}

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -19,5 +19,9 @@ def run():
     assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
 
 
+def test_capsule_resolves_to_ground():
+    run()
+
+
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
## Summary
- Add `root: true` to ESLint JSON config to mark project root
- Add pytest entry point so capsule-ground check runs under pytest

## Testing
- `PYTHONPATH=. pytest`
- `npx eslint .`
- `mypy tests/test_capsule_ground.py`


------
https://chatgpt.com/codex/tasks/task_e_68a043fab6c0832d9d9aaea05e437544