### PR TITLE
Fix capsule voxel SAT module

### DIFF
--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -42,7 +42,7 @@ def capsule_box_penetration(
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
     v = q_seg - q_box
-    dist = float(np.linalg.norm(v))
+    dist = np.linalg.norm(v)
     pen = cap.radius - dist
     if pen > 0.0:
         normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -29,7 +29,7 @@ def closest_point_on_segment(
     """Return the closest point on the line segment *ab* to *p*."""
 
     ab = b - a
-    t = float(np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9))
+    t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
     return a + np.clip(t, 0.0, 1.0) * ab
 
 

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -3,6 +3,7 @@
 from typing import Optional, Protocol, Tuple
 
 import numpy as np
+from numpy.typing import NDArray
 
 from .capsule import Capsule
 
@@ -10,44 +11,48 @@ from .capsule import Capsule
 class WorldProtocol(Protocol):
     """Minimal protocol for the voxel world used in tests."""
 
-    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:  # pragma: no cover - simple protocol
         ...
 
 
-def closest_point_on_aabb(p: np.ndarray, mn: np.ndarray, mx: np.ndarray) -> np.ndarray:
+def closest_point_on_aabb(
+    p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]
+) -> NDArray[np.float32]:
     """Return the closest point on an axis-aligned bounding box to *p*."""
 
     return np.minimum(np.maximum(p, mn), mx)
 
 
-def closest_point_on_segment(p: np.ndarray, a: np.ndarray, b: np.ndarray) -> np.ndarray:
+def closest_point_on_segment(
+    p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]
+) -> NDArray[np.float32]:
     """Return the closest point on the line segment *ab* to *p*."""
 
     ab = b - a
-    t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
+    t = float(np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9))
     return a + np.clip(t, 0.0, 1.0) * ab
 
 
 def capsule_box_penetration(
-    cap: Capsule, mn: np.ndarray, mx: np.ndarray
-) -> Tuple[bool, Optional[np.ndarray], float]:
+    cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]
+) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
     """Check whether *cap* penetrates the axis-aligned box defined by *mn*/*mx*."""
 
     box_center = (mn + mx) * 0.5
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
     v = q_seg - q_box
-    dist = np.linalg.norm(v)
-    pen: float = float(cap.radius - dist)
+    dist = float(np.linalg.norm(v))
+    pen = cap.radius - dist
     if pen > 0.0:
-        n = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-        return True, n, pen
+        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
+        return True, normal, pen
     return False, None, 0.0
 
 
 def resolve_capsule_world(
     cap: Capsule, world: WorldProtocol, max_iters: int = 8
-) -> Tuple[np.ndarray, bool]:
+) -> Tuple[NDArray[np.float32], bool]:
     """Move *cap* out of solid blocks and report ground contact.
 
     This implementation is intentionally simple but sufficient for the unit test.
@@ -76,7 +81,7 @@ def resolve_capsule_world(
                         mn = np.array([x, y, z], dtype=np.float32)
                         mx = mn + 1.0
                         hit, n, pen = capsule_box_penetration(cap, mn, mx)
-                        if hit and pen > 0.0:
+                        if hit and n is not None and pen > 0.0:
                             cap.center += n * pen
                             total_offset += n * pen
                             collided = True
@@ -86,4 +91,3 @@ def resolve_capsule_world(
             break
 
     return total_offset, ground
-


### PR DESCRIPTION
## Summary
- rewrite capsule_voxel_sat physics helpers with proper type hints
- guard against missing collision normal when resolving collisions

## Testing
- `npx eslint .`
- `mypy src/physics/capsule_voxel_sat.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0508b339c832daacc99a2ef88ee72