### PR TITLE
Avoid duplicate CSM source entries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,14 +148,11 @@ if(TARGET VoxelVK_Elite_ALL)
     src/core/gpu_compat.cpp)
 endif()
 
-# --- CSM+PCSS integration sources ---
+# --- CSM integration sources ---
 if(TARGET VoxelVK_Elite_ALL)
-  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_pass.cpp)
-endif()
-
-# --- CSM wiring helpers ---
-if(TARGET VoxelVK_Elite_ALL)
-  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_cpu.cpp src/render/csm_pass.cpp)
+  target_sources(VoxelVK_Elite_ALL PRIVATE
+    src/render/csm_cpu.cpp
+    src/render/csm_pass.cpp)
 endif()
 
 # --- CSM descriptor layout helper ---

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -22,14 +22,11 @@ if(TARGET VoxelVK_Elite_ALL)
     src/core/gpu_compat.cpp)
 endif()
 
-# --- CSM+PCSS integration sources ---
+# --- CSM integration sources ---
 if(TARGET VoxelVK_Elite_ALL)
-  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_pass.cpp)
-endif()
-
-# --- CSM wiring helpers ---
-if(TARGET VoxelVK_Elite_ALL)
-  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_cpu.cpp src/render/csm_pass.cpp)
+  target_sources(VoxelVK_Elite_ALL PRIVATE
+    src/render/csm_cpu.cpp
+    src/render/csm_pass.cpp)
 endif()
 
 # --- CSM descriptor layout helper ---


### PR DESCRIPTION
## Summary
- Consolidate CSM integration sources so `csm_pass.cpp` is added only once per target
- Regenerate build files to remove duplicate source warnings

## Testing
- `cmake -S . -B build`
- `PYTHONPATH=. pytest`
- `npx eslint . -f json`
- `mypy src/physics/capsule.py src/world/persistence.py --ignore-missing-imports --explicit-package-bases`


------
https://chatgpt.com/codex/tasks/task_e_68a0508faa5c832d9bf13b94fd4a914a