### PR TITLE
Clean voxel_solid exports

### DIFF
--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,14 +1,7 @@
-
-
 """Utilities to query whether a voxel block type is solid."""
 
 from typing import Dict
 
-
-from typing import Dict
-
-
-        main
 # Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""
@@ -25,3 +18,6 @@ def is_solid(block_type: int) -> bool:
         return bool(props.get("solid", block_type != BlockType.AIR))
     except Exception:
         return block_type != BlockType.AIR
+
+
+__all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]


### PR DESCRIPTION
## Summary
- remove duplicate typing import and stray text
- limit voxel_solid module exports to BlockType, BLOCK_PROPERTIES, and is_solid

## Testing
- `pytest` *(fails: IndentationError, ModuleNotFoundError)*
- `npx eslint .` *(fails: unexpected token 'export')*
- `mypy .` *(fails: Unexpected indent in src/physics/aabb.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef7451c0832d8e1e7512fe6823f2