### PR TITLE
refactor: clean voxel solid utils

### DIFF
--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,17 +1,11 @@
-
-
 """Utilities to query whether a voxel block type is solid."""
 
 from typing import Dict
 
-
-from typing import Dict
-
-
-        main
 # Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""
+
     AIR = 0
 
 
@@ -25,3 +19,6 @@ def is_solid(block_type: int) -> bool:
         return bool(props.get("solid", block_type != BlockType.AIR))
     except Exception:
         return block_type != BlockType.AIR
+
+
+__all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]


### PR DESCRIPTION
## Summary
- remove duplicate Dict import and stray line in voxel_solid
- expose only BlockType, BLOCK_PROPERTIES, and is_solid

## Testing
- `pytest` (fails: IndentationError in tests/test_capsule_ground.py etc.)
- `npx eslint .` (fails: SyntaxError: Unexpected token 'export')
- `mypy src` (fails: src/physics/aabb.py:6: error: Unexpected indent)


------
https://chatgpt.com/codex/tasks/task_e_68a0f689b16c832d95b8fced7f40d31c