### PR TITLE
docs: fix ESLint command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ Run the test suite:
 ```bash
 pytest
 
+```
+
 ## Linting
 To check JavaScript or TypeScript sources, run:
 ```bash
 npx eslint .
-        main
 ```


### PR DESCRIPTION
## Summary
- remove stray `main` line from ESLint example so code block shows only `npx eslint .`
- close `pytest` block to restore proper README formatting

## Testing
- ⚠️ no tests run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68a0f68d8c74832d8bd2575cb30e0e6e