### PR TITLE
Clean up player controller implementation

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -4,7 +4,6 @@ const globals = require('globals');
 module.exports = [
   {
     ignores: [
-
       'assets/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -15,21 +14,8 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-
-    'apps',
-      'assets',
-      'build_ci_sanity',
-      'cmake',
-      'docs',
-      'node_modules',
-      'scripts',
-      'shaders',
-      'shaders_vk',
-      'tests',
-      'tools'
-        main
-    ]
+      'scripts/**',
+    ],
   },
   js.configs.recommended,
   {
@@ -38,9 +24,10 @@ module.exports = [
       sourceType: 'script',
       globals: {
         ...globals.node,
-        ...globals.es2021
-      }
+        ...globals.es2021,
+      },
     },
-    rules: {}
-  }
+    rules: {},
+  },
 ];
+

--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,9 +1,5 @@
-
-
 """Axis-aligned bounding box helpers for collision tests."""
 
-
-        main
 import numpy as np
 from dataclasses import dataclass
 
@@ -24,7 +20,6 @@ class AABB:
     half: np.ndarray  # (hx,hy,hz) float32
 
     @property
-
     def min(self) -> np.ndarray:
         """Minimum corner of the box."""
         return self.center - self.half
@@ -32,13 +27,6 @@ class AABB:
     @property
     def max(self) -> np.ndarray:
         """Maximum corner of the box."""
-
-    def min(self):
-        return self.center - self.half
-
-    @property
-    def max(self):
-        main
         return self.center + self.half
 
     def moved(self, delta: np.ndarray) -> "AABB":
@@ -48,7 +36,10 @@ class AABB:
     def overlap_aabb(self, other: "AABB") -> bool:
         """Check whether this box overlaps ``other``."""
         return not (
-            self.max[0] <= other.min[0] or self.min[0] >= other.max[0] or
-            self.max[1] <= other.min[1] or self.min[1] >= other.max[1] or
-            self.max[2] <= other.min[2] or self.min[2] >= other.max[2]
+            self.max[0] <= other.min[0]
+            or self.min[0] >= other.max[0]
+            or self.max[1] <= other.min[1]
+            or self.min[1] >= other.max[1]
+            or self.max[2] <= other.min[2]
+            or self.min[2] >= other.max[2]
         )

--- a/src/physics/player_controller.py
+++ b/src/physics/player_controller.py
@@ -1,11 +1,7 @@
-
-
 """AABB-based player controller for movement inside a voxel world."""
 
 from typing import Any, Dict, Tuple
 
-
-        main
 import numpy as np
 
 from .aabb import AABB
@@ -13,7 +9,6 @@ from .voxel_solid import is_solid
 
 
 class PlayerController:
-
     """Axis-aligned bounding box player controller.
 
     Parameters
@@ -29,15 +24,7 @@ class PlayerController:
         world_manager: Any,
         spawn: np.ndarray = np.array([0.0, 100.0, 0.0], dtype=np.float32),
     ) -> None:
-
-    """Simple player controller using an AABB capsule approximation."""
-
-    def __init__(
-        self,
-        world_manager,
-        spawn=np.array([0.0, 100.0, 0.0], dtype=np.float32),
-    ):
-        main
+        """Simple player controller using an AABB capsule approximation."""
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
@@ -52,11 +39,9 @@ class PlayerController:
         self.friction = 12.0
         self.jump_speed = 9.5
         self.step_height = 0.5
+        self.on_ground = False
 
         self.input: Dict[str, int] = {
-
-        self.input = {
-        main
             "f": 0,
             "b": 0,
             "l": 0,
@@ -67,19 +52,13 @@ class PlayerController:
             "sprint": 0,
         }
 
-
     def set_input(self, keymap: Dict[str, int]) -> None:
-        self.input.update({k: int(bool(v)) for k, v in keymap.items() if k in self.input})
-
-    def update(
-        self, dt: float, camera_forward: np.ndarray, camera_right: np.ndarray
-    ) -> None:
-        wish = (camera_forward * (self.input["f"]-self.input["b"]) +
-                camera_right   * (self.input["r"]-self.input["l"]))
-
-    def set_input(self, keymap: dict):
         self.input.update(
-            {k: int(bool(v)) for k, v in keymap.items() if k in self.input}
+            {
+                k: int(bool(v))
+                for k, v in keymap.items()
+                if k in self.input
+            }
         )
 
     def update(
@@ -87,12 +66,11 @@ class PlayerController:
         dt: float,
         camera_forward: np.ndarray,
         camera_right: np.ndarray,
-    ):
+    ) -> None:
         wish = (
             camera_forward * (self.input["f"] - self.input["b"])
             + camera_right * (self.input["r"] - self.input["l"])
         )
-        main
         wish[1] = 0.0
         wl = np.linalg.norm(wish)
         if wl > 1e-6:
@@ -140,17 +118,12 @@ class PlayerController:
         else:
             self.on_ground = False
 
-
     def _sweep_axis(
         self, pos: np.ndarray, axis: int, delta: float
     ) -> Tuple[np.ndarray, bool]:
-        step = np.sign(delta); remaining = abs(delta); hit = False
-
-    def _sweep_axis(self, pos, axis, delta):
         step = np.sign(delta)
         remaining = abs(delta)
         hit = False
-        main
         while remaining > 1e-6:
             advance = min(remaining, 0.1)
             trial = pos.copy()
@@ -161,13 +134,6 @@ class PlayerController:
             else:
                 hi, lo = advance, 0.0
                 for _ in range(8):
-
-                    mid = 0.5*(hi+lo)
-                    trial_mid = pos.copy(); trial_mid[axis] += step*mid
-                    if self._can_occupy(trial_mid): lo = mid
-                    else: hi = mid
-                pos[axis] += step*lo; hit = True; break
-
                     mid = 0.5 * (hi + lo)
                     trial_mid = pos.copy()
                     trial_mid[axis] += step * mid
@@ -178,7 +144,6 @@ class PlayerController:
                 pos[axis] += step * lo
                 hit = True
                 break
-        main
         return pos, hit
 
     def _can_occupy(self, center: np.ndarray) -> bool:
@@ -191,9 +156,10 @@ class PlayerController:
                     bt = self.world.get_block_at_world_position(
                         float(x), float(y), float(z)
                     )
-                    if is_solid(bt):
-                        if self._aabb_voxel_overlap(aabb, x, y, z):
-                            return False
+                    if is_solid(bt) and self._aabb_voxel_overlap(
+                        aabb, x, y, z
+                    ):
+                        return False
         return True
 
     @staticmethod

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,17 +1,11 @@
-
-
 """Utilities to query whether a voxel block type is solid."""
 
 from typing import Dict
 
 
-from typing import Dict
-
-
-        main
-# Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""
+
     AIR = 0
 
 


### PR DESCRIPTION
## Summary
- consolidate duplicate constructors and methods in player controller
- clean up AABB and voxel helper modules for type checking
- add working ESLint configuration

## Testing
- `python -m flake8 src/physics/player_controller.py src/physics/aabb.py src/physics/voxel_solid.py`
- `mypy src/physics/player_controller.py src/physics/aabb.py src/physics/voxel_solid.py`
- `npx eslint -c eslint.config.cjs . --ignore-pattern eslint.config.js`
- `pytest` *(fails: IndentationError in tests and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f68532ac832db153da74ded128e0