### PR TITLE
Add sprint helpers to physics module

### DIFF
--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -1,0 +1,30 @@
+# Shared helpers for player movement physics.
+
+from typing import Any
+
+import numpy as np
+
+
+# Multiplier applied to ``max_speed`` when sprint input is active.
+SPRINT_SPEED_MULTIPLIER = 1.6
+
+
+def get_horizontal_speed(player: Any) -> float:
+    """Return the horizontal speed of the player.
+
+    Parameters
+    ----------
+    player:
+        Object with a ``vel`` attribute representing velocity as a numpy
+        array. Only the X and Z components are considered.
+
+    Returns
+    -------
+    float
+        Magnitude of the horizontal velocity vector.
+    """
+
+    return float(np.linalg.norm(player.vel[[0, 2]]))
+
+
+__all__ = ["SPRINT_SPEED_MULTIPLIER", "get_horizontal_speed"]

--- a/src/physics/player_controller.py
+++ b/src/physics/player_controller.py
@@ -4,10 +4,9 @@
 
 from typing import Any, Dict, Tuple
 
-
-        main
 import numpy as np
 
+from . import SPRINT_SPEED_MULTIPLIER
 from .aabb import AABB
 from .voxel_solid import is_solid
 
@@ -97,7 +96,9 @@ class PlayerController:
         wl = np.linalg.norm(wish)
         if wl > 1e-6:
             wish /= wl
-        target_speed = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
+        target_speed = self.max_speed * (
+            SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
+        )
         accel = self.accel if self.on_ground else self.air_accel
         hv = self.vel.copy()
         hv[1] = 0

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -4,10 +4,9 @@
 
 from typing import Any, Dict
 
-
-        main
 import numpy as np
 
+from . import SPRINT_SPEED_MULTIPLIER
 from .capsule import Capsule
 from .capsule_voxel_sat import resolve_capsule_world
 
@@ -99,7 +98,9 @@ class PlayerControllerCapsule:
         n = np.linalg.norm(wish)
         wish = wish / n if n > 1e-6 else wish
         main
-        target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
+        target = self.max_speed * (
+            SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
+        )
         hv = self.vel.copy()
         hv[1] = 0
         self.vel += (wish * target - hv) * min(

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -97,7 +97,6 @@ class PlayerControllerCapsule:
         wish[1] = 0
         n = np.linalg.norm(wish)
         wish = wish / n if n > 1e-6 else wish
-        main
         target = self.max_speed * (
             SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
         )

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -21,7 +21,3 @@ def test_capsule_ground_collision():
     )
     off, ground = resolve_capsule_world(cap, world)
     assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
-
-
-
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -1,4 +1,8 @@
 import numpy as np
+from src.physics import (
+    SPRINT_SPEED_MULTIPLIER,
+    get_horizontal_speed,
+)
 from src.physics.player_controller_capsule import PlayerControllerCapsule
 
 
@@ -65,7 +69,7 @@ def test_sprint_speed_limit():
     player.set_input({"f": 1})
     for _ in range(20):
         player.update(0.1, forward, right)
-    speed = float(np.linalg.norm(player.vel[[0, 2]]))
+    speed = get_horizontal_speed(player)
     assert speed <= player.max_speed + 1e-3
 
     player.set_input({"sprint": 1})


### PR DESCRIPTION
## Summary
- add `SPRINT_SPEED_MULTIPLIER` and `get_horizontal_speed` to physics package
- use shared multiplier in player controllers
- update sprint tests to import helpers

## Testing
- `PYTHONPATH=. pytest` *(fails: IndentationError in src/physics modules)*
- `PYTHONPATH=. mypy src` *(fails: unexpected indent in src/physics/aabb.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f6821c78832d83491f561b74a1bf