### PR TITLE
docs: fix README linting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Run the test suite:
 
 ```bash
 pytest
+```
 
 ## Linting
 To check JavaScript or TypeScript sources, run:
 ```bash
 npx eslint .
-        main
 ```


### PR DESCRIPTION
## Summary
- close code block for pytest instructions
- document ESLint usage with `npx eslint .`

## Testing
- `python -m markdown README.md`

------
https://chatgpt.com/codex/tasks/task_e_68a0f630c46c832d90606ed6646593ad