### PR TITLE
Remove stray main line from capsule ground test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -21,7 +21,3 @@ def test_capsule_ground_collision():
     )
     off, ground = resolve_capsule_world(cap, world)
     assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
-
-
-
-        main


### PR DESCRIPTION
## Summary
- remove stray line at end of capsule ground test

## Testing
- `pytest -q` (fails: IndentationError: unexpected indent in capsule_voxel_sat.py)
- `mypy --hide-error-context --hide-error-codes --config-file=/dev/null tests/test_capsule_ground.py` (fails: Unexpected indent in capsule_voxel_sat.py)
- `npx eslint .` (fails: SyntaxError in eslint.config.js)


------
https://chatgpt.com/codex/tasks/task_e_68a0f680cd40832db30c7209b4ed5779