### PR TITLE
fix: clean up AABB min/max properties

### DIFF
--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,9 +1,5 @@
-
-
 """Axis-aligned bounding box helpers for collision tests."""
 
-
-        main
 import numpy as np
 from dataclasses import dataclass
 
@@ -24,7 +20,6 @@ class AABB:
     half: np.ndarray  # (hx,hy,hz) float32
 
     @property
-
     def min(self) -> np.ndarray:
         """Minimum corner of the box."""
         return self.center - self.half
@@ -32,13 +27,6 @@ class AABB:
     @property
     def max(self) -> np.ndarray:
         """Maximum corner of the box."""
-
-    def min(self):
-        return self.center - self.half
-
-    @property
-    def max(self):
-        main
         return self.center + self.half
 
     def moved(self, delta: np.ndarray) -> "AABB":


### PR DESCRIPTION
## Summary
- simplify AABB helpers by defining single `min` and `max` properties
- remove duplicate methods and stray text markers

## Testing
- `python -m flake8 src/physics/aabb.py`
- `mypy src/physics/aabb.py`
- `pytest` *(fails: IndentationError in tests, ModuleNotFoundError for 'src')*
- `npx eslint .` *(fails: SyntaxError in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f68a7964832db524e93eeb020d60