### PR TITLE
refactor: deduplicate capsule segment properties

### DIFF
--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -24,24 +24,11 @@ class Capsule:
     radius: float
 
     @property
-
     def seg_a(self) -> np.ndarray:  # top cap center
         """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
+        return self.center + [0, self.half_height, 0]
 
     @property
     def seg_b(self) -> np.ndarray:  # bottom cap center
         """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
-    def seg_a(self):  # top cap center
-        return self.center + np.array(
-            [0, self.half_height, 0], dtype=np.float32
-        )
-
-    @property
-    def seg_b(self):  # bottom cap center
-        return self.center - np.array(
-            [0, self.half_height, 0], dtype=np.float32
-        )
-        main
+        return self.center - [0, self.half_height, 0]


### PR DESCRIPTION
## Summary
- remove duplicate segment accessors from capsule shape

## Testing
- `python -m pytest` *(fails: IndentationError in tests/test_capsule_ground.py, IndentationError in src/physics/player_controller_capsule.py)*
- `mypy src` *(fails: Unexpected indent in src/physics/aabb.py)*
- `npx eslint .` *(fails: Unexpected token 'export' in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f70d970c832dbbe06d16fdd9237b