### PR TITLE
fix voxel_solid imports

### DIFF
--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,14 +1,7 @@
-
-
 """Utilities to query whether a voxel block type is solid."""
 
 from typing import Dict
 
-
-from typing import Dict
-
-
-        main
 # Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""


### PR DESCRIPTION
## Summary
- clean up voxel_solid by removing duplicate typing import and stray text

## Testing
- `npx eslint -c eslint.config.cjs .` *(fails: Unexpected string in eslint.config.cjs)*
- `mypy src` *(fails: Unexpected indent in src/physics/aabb.py)*
- `pytest` *(fails: errors during test collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7116698832da82b31f606ce9126