### PR TITLE
refactor: simplify eslint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,28 +1,9 @@
-
-export default {
-};
-
-
-export default [
-  {
-    files: ["**/*.{js,ts}"]
-
 /** @type {import('eslint').Linter.FlatConfig[]} */
-module.exports = [
+export default [
+  { ignores: ['**/build/**', 'eslint.config.cjs'] },
   {
-    ignores: ["**/build/**"]
-  },
-  {
-    files: ["**/*.{js,jsx,ts,tsx}"],
-    languageOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module"
-    },
-    rules: {
-      "no-unused-vars": "warn",
-      "semi": ["error", "always"]
-    }
-        main
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    languageOptions: { ecmaVersion: 2020, sourceType: 'module' },
+    rules: { 'no-unused-vars': 'warn', 'semi': ['error', 'always'] }
   }
 ];
-        main

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 /** @type {import('eslint').Linter.FlatConfig[]} */
 export default [
-  { ignores: ['**/build/**', 'eslint.config.cjs'] },
+  { ignores: ['**/build/**'] },
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: { ecmaVersion: 2020, sourceType: 'module' },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "vulken-3d-world",
   "version": "1.0.0",
   "description": "[![CI](https://github.com/vulken-dev/vulken-3d-world/actions/workflows/ci.yml/badge.svg)](https://github.com/vulken-dev/vulken-3d-world/actions/workflows/ci.yml)",
-  "main": "index.js",
   "directories": {
     "doc": "docs",
     "test": "tests"
@@ -13,7 +12,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "eslint": "^9.33.0",


### PR DESCRIPTION
## Summary
- replace broken ESLint config with single export and rules
- drop stray `main` entry and switch package to ESM for linting

## Testing
- `npx eslint .`
- `pytest` *(fails: IndentationError in tests/test_capsule_ground.py, ModuleNotFoundError for src imports)*
- `mypy .` *(fails: Unexpected indent in src/physics/aabb.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7172414832d96172dcff4b8a1d2