### PR TITLE
docs: remove stray lint line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,4 @@ pytest
 To check JavaScript or TypeScript sources, run:
 ```bash
 npx eslint .
-        main
 ```


### PR DESCRIPTION
## Summary
- fix linting code block in README by removing stray 'main' line

## Testing
- `npx markdownlint-cli README.md` *(fails: existing style issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f77617ac832d8ee9c34c6703bf81