### PR TITLE
chore: remove stray main from test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -21,7 +21,3 @@ def test_capsule_ground_collision():
     )
     off, ground = resolve_capsule_world(cap, world)
     assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
-
-
-
-        main


### PR DESCRIPTION
## Summary
- tidy test file by removing stray `main` line and trailing blank space

## Testing
- `pytest -q` *(fails: IndentationError in src/physics files)*
- `npx eslint .` *(fails: SyntaxError: Unexpected token 'export' in eslint.config.js)*
- `mypy .` *(fails: Unexpected indent in src/physics/aabb.py)*
- `pytest tests/test_capsule_ground.py -q` *(fails: IndentationError in src/physics/capsule_voxel_sat.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f7c0ae30832d95cb2a14c2b1574e