### PR TITLE
Add SDL2/OpenGL voxel viewer sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ Run it:
         main
 ```
 
+### viewer
+Build the viewer:
+```bash
+cmake -S . -B build
+cmake --build build --target viewer
+```
+
+Generate a small sample world (chunk 0,0) using the Python `ChunkStore`:
+```bash
+python - <<'PY'
+import numpy as np
+from src.world.persistence import ChunkStore
+class Chunk: pass
+chunk=Chunk(); chunk.position=(0,0)
+chunk.voxels=np.random.randint(0,255,(16,16,16),dtype=np.uint8)
+store=ChunkStore(root="sample_world", codec="zstd", use_rle=True, threads=1)
+store.save_chunk_sync(chunk)
+PY
+```
+
+Run the viewer and point it at the generated world directory:
+```bash
+./build/apps/viewer sample_world
+```
+
 ## World streaming and LOD
 Chunks are loaded asynchronously around the player using the `ChunkStreamer` module. Mesh detail is selected by a distance-based LOD component configured through `world_lod.cfg`:
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,4 +1,8 @@
 find_package(Vulkan REQUIRED)
+find_package(SDL2 REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package(ZSTD REQUIRED)
+find_package(Threads REQUIRED)
 
 # --- Build tagging injection ---
 set(VOXELVK_BRANCH_SOURCES "project_fixed + VoxelVK_Elite_ALL_release_ready + voxel_upgrades_patch + project_compute_graphics_chain + project_dynamic_pbr + project_next_tier_all")
@@ -15,6 +19,11 @@ add_executable(smoke_graphics_headless smoke_graphics_headless.cpp)
 set_target_properties(smoke_graphics_headless PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 target_include_directories(smoke_graphics_headless PRIVATE ${CMAKE_BINARY_DIR}/generated)
 target_link_libraries(smoke_graphics_headless PRIVATE Vulkan::Vulkan)
+
+add_executable(viewer viewer.cpp ${CMAKE_SOURCE_DIR}/src/world/persistence.cpp)
+set_target_properties(viewer PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YES)
+target_include_directories(viewer PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(viewer PRIVATE SDL2::SDL2 SDL2::SDL2main OpenGL::GL ZSTD::ZSTD Threads::Threads)
 
 # --- Build tagging sources ---
 list(APPEND VOXELVK_ELITE_SOURCES

--- a/apps/viewer.cpp
+++ b/apps/viewer.cpp
@@ -1,0 +1,94 @@
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
+#include <GL/glu.h>
+#include <iostream>
+#include <vector>
+
+#include "world/persistence.hpp"
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: viewer <world_dir>\n";
+        return 1;
+    }
+
+    std::string root = argv[1];
+    world::ChunkStore store(root, "zstd", true);
+    auto chunk = store.load_chunk(0, 0);
+    if (!chunk) {
+        std::cerr << "Failed to load chunk at 0,0\n";
+        return 1;
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        std::cerr << "SDL_Init failed: " << SDL_GetError() << "\n";
+        return 1;
+    }
+
+    SDL_Window* win = SDL_CreateWindow("viewer", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                       800, 600, SDL_WINDOW_OPENGL);
+    if (!win) {
+        std::cerr << "SDL_CreateWindow failed: " << SDL_GetError() << "\n";
+        SDL_Quit();
+        return 1;
+    }
+
+    SDL_GLContext ctx = SDL_GL_CreateContext(win);
+    if (!ctx) {
+        std::cerr << "SDL_GL_CreateContext failed: " << SDL_GetError() << "\n";
+        SDL_DestroyWindow(win);
+        SDL_Quit();
+        return 1;
+    }
+
+    glEnable(GL_DEPTH_TEST);
+    glPointSize(4.0f);
+
+    bool running = true;
+    float angle = 0.0f;
+    while (running) {
+        SDL_Event e;
+        while (SDL_PollEvent(&e)) {
+            if (e.type == SDL_QUIT) running = false;
+        }
+
+        glClearColor(0.1f, 0.1f, 0.15f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        gluPerspective(60.0, 800.0 / 600.0, 0.1, 1000.0);
+
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        glTranslatef(-chunk->size / 2.0f, -chunk->height / 2.0f, -chunk->size * 2.0f);
+        glRotatef(angle, 0.0f, 1.0f, 0.0f);
+        angle += 0.5f;
+
+        glBegin(GL_POINTS);
+        const auto& vox = chunk->voxels;
+        int S = chunk->size;
+        int H = chunk->height;
+        for (int y = 0; y < H; ++y) {
+            for (int z = 0; z < S; ++z) {
+                for (int x = 0; x < S; ++x) {
+                    std::size_t idx = x + z * S + y * S * S;
+                    std::uint8_t v = vox[idx];
+                    if (v) {
+                        glColor3ub(v, v, v);
+                        glVertex3f(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+                    }
+                }
+            }
+        }
+        glEnd();
+
+        SDL_GL_SwapWindow(win);
+        SDL_Delay(16);
+    }
+
+    SDL_GL_DeleteContext(ctx);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add SDL2/OpenGL viewer that loads a saved chunk via ChunkStore and renders voxels as points
- Hook viewer into CMake build and link SDL2, OpenGL, zstd, and threads
- Document building the viewer and running it against sample worldgen output

## Testing
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `pytest` *(fails: syntax errors in tests/test_player_controller_capsule.py)*
- `mypy` *(fails: mypy.ini option duplication)*

------
https://chatgpt.com/codex/tasks/task_e_68a1728cdec0832d8431503f72a08ee3