### PR TITLE
Add worldgen palette and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ medium_detail=60
 ```
 
 Adjust these thresholds to control when medium or low detail meshes are chosen.
+
+## World Generation Assets
+
+Palette definitions and structure templates used for world generation are located under `assets/worldgen`. Palettes describe block sets, while templates outline prefab structures like trees and houses.

--- a/assets/worldgen/palettes/basic.json
+++ b/assets/worldgen/palettes/basic.json
@@ -1,0 +1,4 @@
+{
+  "name": "basic",
+  "blocks": ["grass", "dirt", "stone"]
+}

--- a/assets/worldgen/templates/house.json
+++ b/assets/worldgen/templates/house.json
@@ -1,0 +1,17 @@
+{
+  "name": "house",
+  "structure": [
+    {"block": "stone", "position": [0, 0, 0]},
+    {"block": "stone", "position": [1, 0, 0]},
+    {"block": "stone", "position": [0, 0, 1]},
+    {"block": "stone", "position": [1, 0, 1]},
+    {"block": "wood", "position": [0, 1, 0]},
+    {"block": "wood", "position": [1, 1, 0]},
+    {"block": "wood", "position": [0, 1, 1]},
+    {"block": "wood", "position": [1, 1, 1]},
+    {"block": "stone", "position": [0, 2, 0]},
+    {"block": "stone", "position": [1, 2, 0]},
+    {"block": "stone", "position": [0, 2, 1]},
+    {"block": "stone", "position": [1, 2, 1]}
+  ]
+}

--- a/assets/worldgen/templates/tree.json
+++ b/assets/worldgen/templates/tree.json
@@ -1,0 +1,12 @@
+{
+  "name": "tree",
+  "structure": [
+    {"block": "wood", "position": [0, 0, 0]},
+    {"block": "wood", "position": [0, 1, 0]},
+    {"block": "leaf", "position": [0, 2, 0]},
+    {"block": "leaf", "position": [1, 2, 0]},
+    {"block": "leaf", "position": [-1, 2, 0]},
+    {"block": "leaf", "position": [0, 2, 1]},
+    {"block": "leaf", "position": [0, 2, -1]}
+  ]
+}

--- a/tests/test_worldgen_assets.py
+++ b/tests/test_worldgen_assets.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+
+def test_basic_palette():
+    path = Path('assets/worldgen/palettes/basic.json')
+    data = json.loads(path.read_text())
+    assert data["name"] == "basic"
+    assert "blocks" in data and data["blocks"], "Palette must define blocks"
+
+
+def test_structure_templates():
+    templates = ['tree.json', 'house.json']
+    for tpl in templates:
+        path = Path('assets/worldgen/templates') / tpl
+        data = json.loads(path.read_text())
+        assert "structure" in data and data["structure"], f"{tpl} should define structure"


### PR DESCRIPTION
## Summary
- add basic world generation palette
- add tree and house structure templates
- test palette and templates and document their location

## Testing
- `python -m pytest` *(fails: SyntaxError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: duplicate option explicit_package_bases)*

------
https://chatgpt.com/codex/tasks/task_e_68a1729ebbe8832db89e1924e84601fb