### PR TITLE
docs: fix README formatting and assets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,11 @@ Run the test suite:
 pytest
 ```
 
-```
-
 ## Linting
 To check JavaScript or TypeScript sources, run:
 ```bash
 npx eslint .
-
-
-
-
+```
 ## Samples
 
 ### demo_window
@@ -59,9 +54,6 @@ cmake --build build --target demo_window
 Run it:
 ```bash
 ./build/demo_window
-        main
-        main
-        main
 ```
 
 ## World streaming and LOD
@@ -74,3 +66,8 @@ medium_detail=60
 ```
 
 Adjust these thresholds to control when medium or low detail meshes are chosen.
+
+## World Generation Assets
+Example terrain assets live in the `assets` directory. Material properties, such as albedo and roughness, are defined in
+`assets/config/materials.json`. Replace these placeholders with your own files to experiment with different block types or
+biome palettes during world generation.


### PR DESCRIPTION
## Summary
- remove stray `main` lines and close code fences in README
- add World Generation Assets section explaining placeholder data

## Testing
- ⚠️ no tests run, documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68a174e10ec4832dbe30b5ce05bf4258