### PR TITLE
Simplify ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,118 +1,35 @@
-
 const js = require('@eslint/js');
+const globals = require('globals');
 
-
-        main
 module.exports = [
   {
-
-    ignores: ['node_modules/**'],
-
     ignores: [
-
-
-
       '**/build/**',
-
-
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-  }
-
-
-      'assets/**', 'build_ci_sanity/**', 'cmake/**',
-      'docs/**', 'shaders/**', 'shaders_vk/**',
-      'tools/**'
-    ]
-
-        main
-        main
-        main
-        main
-      'assets/**',
+      'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
+      'assets/**',
       'shaders/**',
       'shaders_vk/**',
       'tools/**',
       'tests/**',
       'src/**',
-      'eslint.config.js',
       'apps/**',
       'scripts/**',
-
-      'node_modules/**'
-
-
-      'node_modules/**'
-
-
-      'scripts/**'
+      'eslint.config.js'
     ]
-
-
-      'scripts/**'
-        main
-        main
-    ]
-
-    ],
-        main
-       main
-        main
-        main
   },
-
-  js.configs.recommended
-
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-
       globals: { ...globals.node, ...globals.es2021 }
-
-      globals: {
-        ...globals.node,
-        ...globals.es2021,
-      },
-
     },
-
     rules: {
       'no-unused-vars': 'warn',
       semi: ['error', 'always']
     }
   }
-
-
-    rules: {
-      'no-unused-vars': 'warn',
-      semi: ['error', 'always'],
-    },
-  },
-
-        main
-    },
-    rules: {},
-  },
-        main
-        main
-        main
-        main
 ];
-


### PR DESCRIPTION
## Summary
- replace eslint.config.cjs with minimal module.exports structure
- consolidate ignore patterns and reapply recommended config

## Testing
- `npx eslint .`
- `pytest` *(fails: IndentationError in tests)*
- `mypy` *(fails: duplicate option in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a174e40410832da2e925024876a8b5