### PR TITLE
chore: simplify mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
 exclude = ^src/physics/
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-        main


### PR DESCRIPTION
## Summary
- remove duplicate explicit_package_bases line and stray text from mypy.ini

## Testing
- `pytest` (fails: IndentationError in tests)
- `npx eslint .` (fails: SyntaxError in ESLint config)
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68a1752e9bd8832d8b42810246f888b1