### PR TITLE
docs: fix linting code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,11 @@ Run the test suite:
 pytest
 ```
 
-```
-
 ## Linting
 To check JavaScript or TypeScript sources, run:
 ```bash
 npx eslint .
-
-
-
+```
 
 ## Samples
 


### PR DESCRIPTION
## Summary
- fix markdown formatting around Linting section in README

## Testing
- `npx markdown-it README.md > /tmp/readme.html`


------
https://chatgpt.com/codex/tasks/task_e_68a17532fe30832dadb861636462a56c