### PR TITLE
Fix cmake workflow artifact uploads

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,21 +29,21 @@ jobs:
         run: cmake --build build -j
       - name: Test
         run: ctest --test-dir build --output-on-failure
-      - name: Upload build artifacts
-
+      - name: Upload build artifacts (v4)
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: build-linux-${{ runner.os }}
           path: build
 
+      - name: Upload build artifacts (v3)
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: build-${{ runner.os }}
           path: |
             build/**
           if-no-files-found: ignore
-        main
 
   windows:
     runs-on: windows-latest
@@ -67,18 +67,18 @@ jobs:
         run: cmake --build build -j
       - name: Test
         run: ctest --test-dir build --output-on-failure
-      - name: Upload build artifacts
-
+      - name: Upload build artifacts (v4)
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ runner.os }}
           path: build
 
+      - name: Upload build artifacts (v3)
+        if: ${{ always() }}
         uses: actions/upload-artifact@v3
         with:
           name: build-${{ runner.os }}
           path: |
             build/**
           if-no-files-found: ignore
-        main


### PR DESCRIPTION
## Summary
- split artifact upload step to avoid duplicate `uses` and stray `main`

## Testing
- `npx eslint .` *(fails: SyntaxError: Unexpected string in eslint.config.cjs)*
- `pytest` *(fails: IndentationError in tests/test_capsule_ground.py)*
- `mypy` *(fails: mypy.ini option 'explicit_package_bases' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a175c1369c832d8014032342e843a1