### PR TITLE
chore: ensure Vulkan tool checks fail on error

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,11 @@ jobs:
           sudo apt-get install -y ninja-build cmake g++ libvulkan-dev vulkan-validationlayers-dev glslang-tools libglfw3-dev
       - name: Set Vulkan env
         run: echo "VULKAN_SDK=/usr" >> $GITHUB_ENV
+      - name: Check Vulkan tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          glslc --version
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build
@@ -61,6 +66,11 @@ jobs:
         run: choco install vulkan-sdk glfw --yes
       - name: Set Vulkan env
         run: echo "VULKAN_SDK=C:\VulkanSDK\latest" >> $Env:GITHUB_ENV
+      - name: Check Vulkan tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          glslc --version
       - name: Configure
         run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build


### PR DESCRIPTION
## Summary
- ensure GitHub Actions 'Check Vulkan tools' steps abort on errors by adding `set -euo pipefail`

## Testing
- `pytest` *(fails: IndentationError, SyntaxError)*
- `npx eslint .` *(fails: ESLint config SyntaxError)*
- `mypy` *(fails: duplicate option in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a175c0790c832dbdc9448e41be33fa