### PR TITLE
Restore player controller capsule tests

### DIFF
--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -1,37 +1,24 @@
+"""Lightweight physics helpers used in tests.
 
-"""Legacy Python physics helpers.
+This package only provides a small set of utilities required by the unit
+tests.  The C++ equivalents in ``src/physics_cpp`` are preferred for any
+real gameplay logic.
+"""
 
-These modules are retained for reference only. C++ equivalents live in
-``src/physics_cpp`` and should be preferred for production use."""
-
-# Shared helpers for player movement physics.
+from __future__ import annotations
 
 from typing import Any
 
 import numpy as np
 
-
 # Multiplier applied to ``max_speed`` when sprint input is active.
-SPRINT_SPEED_MULTIPLIER = 1.6
+SPRINT_SPEED_MULTIPLIER: float = 1.6
 
 
 def get_horizontal_speed(player: Any) -> float:
-    """Return the horizontal speed of the player.
-
-    Parameters
-    ----------
-    player:
-        Object with a ``vel`` attribute representing velocity as a numpy
-        array. Only the X and Z components are considered.
-
-    Returns
-    -------
-    float
-        Magnitude of the horizontal velocity vector.
-    """
+    """Return the magnitude of the player's horizontal velocity."""
 
     return float(np.linalg.norm(player.vel[[0, 2]]))
 
 
 __all__ = ["SPRINT_SPEED_MULTIPLIER", "get_horizontal_speed"]
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,13 +1,7 @@
-
-
-import numpy as np
-
-        main
 """Definition of a vertical capsule shape used for collision queries."""
 
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
 
 import numpy as np
@@ -16,62 +10,27 @@ from numpy.typing import NDArray
 
 @dataclass
 class Capsule:
-  center: np.ndarray
-
-    """Vertical capsule represented by a center point, half-height and radius."""
+    """Vertical capsule defined by center, half-height and radius."""
 
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-
-
-    def seg_a(self) -> np.ndarray:
-        main
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray: 
-      
-      """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
-
-    def seg_a(self) -> np.ndarray:
-
-    def seg_a(self) -> np.ndarray:
-
     def seg_a(self) -> NDArray[np.float32]:
-        main
-        main
         """Center of the top spherical cap."""
 
-        return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
+        return self.center + np.array(
+            [0.0, self.half_height, 0.0], dtype=np.float32
+        )
 
     @property
-
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
-
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_b(self) -> NDArray[np.float32]:
         """Center of the bottom spherical cap."""
 
-        return self.center - np.array([0.0, self.half_height, 0.0], dtype=np.float32)
+        return self.center - np.array(
+            [0.0, self.half_height, 0.0], dtype=np.float32
+        )
 
-        main
-        main
-        main
-        main
+
+__all__ = ["Capsule"]

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,57 +1,45 @@
-
-import numpy as np
-from typing import Any, Tuple
-
-
-"""Collision detection between a capsule and a voxel grid using simple axis tests."""
-
-
-from typing import Any, Tuple
-
-
-"""Collision helpers for capsule vs voxel world using SAT."""
-
-from typing import Any, Optional, Tuple, cast
-
-"""Capsule collision helpers for a voxel world using simple SAT tests."""
+"""Collision helpers for a capsule against a simple voxel world."""
 
 from __future__ import annotations
 
-from typing import Any, Optional, Protocol, Tuple
-        main
+from typing import Any, Tuple
 
-        main
 import numpy as np
 
-        main
 from .capsule import Capsule
 
 
 def resolve_capsule_world(cap: Capsule, world: Any) -> Tuple[np.ndarray, bool]:
+    """Resolve penetration of ``cap`` against blocks provided by ``world``.
 
-    """Very small helper used in tests to keep the capsule above solid blocks.
-
-    The world object only needs ``get_block_at_world_position``. We check voxels
-    overlapping the capsule's bounding box and push the capsule upward if a
-    solid block is encountered. The routine is intentionally simplistic but
-    sufficient for unit tests covering ground contact and basic step climbing.
+    The ``world`` object is expected to implement
+    ``get_block_at_world_position(x, y, z)`` returning a truthy value for solid
+    blocks.  The routine is intentionally simple but sufficient for the unit
+    tests which only exercise flat ground and single-block steps.
     """
 
     off = np.zeros(3, dtype=np.float32)
     ground = False
 
-    # Compute capsule bounding box
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+    # Bounding box of the capsule
+    mn = cap.center - np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
+    )
+    mx = cap.center + np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
+    )
     bb_min = np.floor(mn).astype(int)
     bb_max = np.floor(mx).astype(int)
 
     for y in range(bb_min[1], bb_max[1] + 1):
         for z in range(bb_min[2], bb_max[2] + 1):
             for x in range(bb_min[0], bb_max[0] + 1):
-                if not is_solid(world.get_block_at_world_position(float(x), float(y), float(z))):
+                if not world.get_block_at_world_position(
+                    float(x), float(y), float(z)
+                ):
                     continue
-                # push upwards so bottom sits on top of block
                 block_top = y + 1.0
                 bottom = cap.center[1] - (cap.half_height + cap.radius)
                 if bottom < block_top:
@@ -59,202 +47,8 @@ def resolve_capsule_world(cap: Capsule, world: Any) -> Tuple[np.ndarray, bool]:
                     cap.center[1] += delta
                     off[1] += delta
                     ground = True
+
     return off, ground
 
-    """Resolve capsule collision against a voxel world.
 
-
-    The ``world`` object exposes ``get_block_at_world_position`` which returns
-    a truthy value for solid blocks. The resolution used here is deliberately
-    simple and only handles the cases exercised in the tests: flat ground and
-    one-block-high steps.
-    """
-    off = np.zeros(3, dtype=np.float32)
-    grounded = False
-
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius])
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius])
-
-    for y in range(int(np.floor(mn[1])), int(np.ceil(mx[1]))):
-        for z in range(int(np.floor(mn[2])), int(np.ceil(mx[2]))):
-    for y in range(int(np.floor(mn[1] - 0.5)), int(np.ceil(mx[1]))):
-        for z in range(int(np.floor(mn[2] - 0.5)), int(np.ceil(mx[2]))):
-            for x in range(int(np.floor(mn[0] - 0.5)), int(np.ceil(mx[0]))):
-                if world.get_block_at_world_position(float(x), float(y), float(z)):
-                    top = y + 1.0
-                    bottom = cap.center[1] - cap.half_height - cap.radius
-                    if bottom < top:
-                        delta = top - bottom
-                        if delta > off[1]:
-                            off[1] = delta
-                        off[1] += delta
-                        grounded = True
-
-                    # Compute penetration along each axis
-                    block_min = np.array([x, y, z], dtype=np.float32)
-                    block_max = block_min + 1.0
-                    cap_min = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius])
-                    cap_max = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius])
-
-                    # Calculate overlap along each axis
-                    overlap = np.zeros(3, dtype=np.float32)
-                    for axis in range(3):
-                        if cap_max[axis] > block_min[axis] and cap_min[axis] < block_max[axis]:
-                            min_pen = block_max[axis] - cap_min[axis]
-                            max_pen = cap_max[axis] - block_min[axis]
-                            # Choose the smaller penetration
-                            if min_pen < max_pen:
-                                overlap[axis] = min_pen
-                            else:
-                                overlap[axis] = -max_pen
-                        else:
-                            overlap[axis] = 0.0
-
-                    # Find axis of minimum penetration (MTV)
-                    abs_overlap = np.abs(overlap)
-                    axis = np.argmax(abs_overlap)
-                    if abs_overlap[axis] > 0.0:
-                        if abs_overlap[axis] > abs(off[axis]):
-                            off[axis] = overlap[axis]
-                            if axis == 1 and overlap[1] > 0.0:
-                                grounded = True
-
-    cap.center += off
-    return off, grounded
-
-def closest_point_on_aabb(
-    p: np.ndarray, mn: np.ndarray, mx: np.ndarray
-) -> np.ndarray:
-    """Return the closest point on an axis-aligned box to ``p``."""
-    return np.minimum(np.maximum(p, mn), mx)
-
-
-def closest_point_on_segment(
-    p: np.ndarray, a: np.ndarray, b: np.ndarray
-) -> np.ndarray:
-    """Return the closest point on the segment ``ab`` to ``p``."""
-    
-class WorldProtocol(Protocol):
-    """Minimal protocol required from the voxel world used in tests."""
-
-    def get_block_at_world_position(self, x: float, y: float, z: float) -> int: ...
-
-
-def closest_point_on_aabb(p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]) -> NDArray[np.float32]:
-    """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
-
-    return np.minimum(np.maximum(p, mn), mx)
-
-
-def closest_point_on_segment(p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]) -> NDArray[np.float32]:
-    """Return the closest point on the segment ``ab`` to ``p``."""
-
-        main
-    ab = b - a
-    t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
-    return a + np.clip(t, 0.0, 1.0) * ab
-
-
-
-def capsule_box_penetration(
-    cap: Capsule, mn: np.ndarray, mx: np.ndarray
-) -> Tuple[bool, Optional[np.ndarray], float]:
-    """Compute penetration of ``cap`` against an axis-aligned box."""
-
-def capsule_box_penetration(cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
-    """Check penetration of ``cap`` against an axis-aligned box."""
-
-        main
-    box_center = (mn + mx) * 0.5
-    q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
-    q_box = closest_point_on_aabb(q_seg, mn, mx)
-    v = q_seg - q_box
-
-    dist = np.linalg.norm(v)
-
-    pen = cap.radius - dist
-    if pen > 0.0:
-        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-        return True, cast(np.ndarray, normal), float(pen)
-    return False, None, 0.0
-
-
-def resolve_capsule_world(
-    cap: Capsule, world: Any, max_iters: int = 8
-) -> Tuple[np.ndarray, bool]:
-    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
-
-    dist = float(np.linalg.norm(v))
-    pen = float(cap.radius - dist)
-    if pen > 0.0:
-        n = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-        return True, n, pen
-    return False, None, 0.0
-
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
-    """Return integer min/max voxel coordinates overlapped by ``cap``."""
-
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    return np.floor(mn).astype(int), np.floor(mx).astype(int)
-
-
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol, max_iters: int = 8) -> Tuple[NDArray[np.float32], bool]:
-    """Move *cap* out of solid voxels in ``world`` and report ground contact."""
-
-        main
-    total_offset = np.zeros(3, dtype=np.float32)
-    ground = False
-
-    for _ in range(max_iters):
-        )  
-        mn = cap.center - np.array(
-            [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
-        )
-        mx = cap.center + np.array(
-            [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
-        )
-        bb_min = np.floor(mn).astype(int)
-        bb_max = np.floor(mx).astype(int)
-
-        max_pen = 0.0
-        hit_n: Optional[np.ndarray] = None
-        for y in range(bb_min[1] - 1, bb_max[1] + 2):
-            for z in range(bb_min[2] - 1, bb_max[2] + 2):
-                for x in range(bb_min[0] - 1, bb_max[0] + 2):
-                    bt = world.get_block_at_world_position(float(x), float(y), float(z))
-                    if not bt:
-
-        bb_min, bb_max = compute_capsule_voxel_bounds(cap)
-        max_pen = 0.0
-        hit_n: Optional[NDArray[np.float32]] = None
-        contact_n: Optional[NDArray[np.float32]] = None
-        for y in range(bb_min[1] - 1, bb_max[1] + 2):
-            for z in range(bb_min[2] - 1, bb_max[2] + 2):
-                for x in range(bb_min[0] - 1, bb_max[0] + 2):
-                    if world.get_block_at_world_position(float(x), float(y), float(z)) == 0:
-         main
-                        continue
-                    mn = np.array([x, y, z], dtype=np.float32)
-                    mx = mn + 1.0
-                    hit, n, pen = capsule_box_penetration(cap, mn, mx)
-                    if hit and pen > max_pen and n is not None:
-                        max_pen, hit_n = pen, n
-        if max_pen <= 1e-6 or hit_n is None:
-            break
-        off = hit_n * max_pen
-        cap.center += off
-        total_offset += off
-
-        if hit_n is not None and hit_n[1] > 0.7:
-            ground = True
-
-
-        if contact_n is not None and contact_n[1] > 0.7:
-            ground = True
-        main
-    return total_offset, ground
-
-        main
-        main
+__all__ = ["resolve_capsule_world"]

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -1,130 +1,19 @@
-
-
-
-
-
 """Simple capsule-based player controller used in tests."""
 
 from __future__ import annotations
 
-        main
-        main
-"""Capsule-based player controller using SAT collision resolution."""
-        main
-
 from typing import Any, Dict
 
-       main
 import numpy as np
-from typing import Any, Dict
 
-from . import SPRINT_SPEED_MULTIPLIER
+from . import SPRINT_SPEED_MULTIPLIER, get_horizontal_speed
 from .capsule import Capsule
 from .capsule_voxel_sat import resolve_capsule_world
 
-SPRINT_SPEED_MULTIPLIER = 1.6
-
-
-def get_horizontal_speed(controller: "PlayerControllerCapsule") -> float:
-    """Return the horizontal speed of the controller."""
-    return float(np.linalg.norm(controller.vel[[0, 2]]))
-
-
-SPRINT_SPEED_MULTIPLIER = 1.6
-
-
-
-def get_horizontal_speed(pc: "PlayerControllerCapsule") -> float:
-    """Return the horizontal speed magnitude of the player."""
-    return float(np.linalg.norm(pc.vel[[0, 2]]))
-
-
-class PlayerControllerCapsule:
-    """Capsule-based player controller."""
-
-_first_speed_call = True
-
-
-def get_horizontal_speed(pc: "PlayerControllerCapsule") -> float:
-    """Return the magnitude of the horizontal velocity for *pc*.
-
-    The first call clamps the value to ``pc.max_speed`` to satisfy test
-    expectations; subsequent calls return the true speed.
-
-class PlayerControllerCapsule:
-"""Capsule-based player controller."""
-
-    """Capsule-based player controller.
-
-    Parameters
-    ----------
-    world_manager:
-        World accessor providing ``get_block_at_world_position``.
-    spawn:
-        Initial spawn position of the player.
-    step_height, gravity, max_speed, jump_speed:
-        Tuning parameters for character movement.
-
-
-
-    Example
-    -------
-    >>> pc = PlayerControllerCapsule(
-    ...     world, np.array([0.0, 1.0, 0.0], dtype=np.float32)
-    ... )
-    >>> forward = np.array([0.0, 0.0, 1.0], dtype=np.float32)
-    >>> right = np.array([1.0, 0.0, 0.0], dtype=np.float32)
-    >>> pc.update(0.016, forward, right)
-        main
-        main
-    """
-        main
-
-    global _first_speed_call
-    speed = float(np.linalg.norm(pc.vel[[0, 2]]))
-    if _first_speed_call:
-        _first_speed_call = False
-        return min(speed, pc.max_speed + 1e-3)
-    return speed
 
 class PlayerControllerCapsule:
     """Basic kinematic character controller represented by a capsule."""
 
-
-
-
-
-
-
-
-
-
-        main
-
-
-
-
-
-
-
-
-class PlayerControllerCapsule:
-    """Basic kinematic character controller represented by a capsule."""
-
-    _first_speed_call = True
-
-    def get_horizontal_speed(self) -> float:
-        """Return the magnitude of the horizontal velocity for this instance.
-
-        The first call clamps the value to ``self.max_speed`` to satisfy test
-        expectations; subsequent calls return the true speed.
-        """
-        speed = float(np.linalg.norm(self.vel[[0, 2]]))
-        if PlayerControllerCapsule._first_speed_call:
-            PlayerControllerCapsule._first_speed_call = False
-            return min(speed, self.max_speed + 1e-3)
-        return speed
-    """Basic kinematic character controller represented by a capsule."""
     def __init__(
         self,
         world_manager: Any,
@@ -145,30 +34,6 @@ class PlayerControllerCapsule:
         self.jump_speed = jump_speed
         self.on_ground = False
 
-        self.input: Dict[str, int] = {"f":0,"b":0,"l":0,"r":0,"jump":0,"sprint":0}
-
-    def set_input(self, mapping: Dict[str, int]) -> None:
-        self.input.update(mapping)
-
-
-
-        main
-
-    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
-        wish = (forward*(self.input["f"]-self.input["b"]) +
-                right*(self.input["r"]-self.input["l"]))
-        wish[1] = 0.0
-        n = np.linalg.norm(wish)
-        wish = wish/n if n>1e-6 else wish
-        target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
-        hv = self.vel.copy(); hv[1] = 0
-        accel = 50.0 if self.on_ground else 10.0
-        self.vel += (wish*target - hv) * min(1.0, accel*dt)
-
-
-        main
-        main
-        main
         self.input: Dict[str, int] = {
             "f": 0,
             "b": 0,
@@ -179,79 +44,36 @@ class PlayerControllerCapsule:
         }
 
     def set_input(self, mapping: Dict[str, int]) -> None:
+        """Update input state with values from ``mapping``."""
 
-"""Update input state with values from ``mapping``."""
         self.input.update(mapping)
 
     def _capsule(self) -> Capsule:
         """Return a capsule representing the player's current bounds."""
+
         return Capsule(self.pos.copy(), self.half_h, self.radius)
-
-    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
-        """Advance the controller by ``dt`` seconds."""
-
-        self.input.update(mapping)
-
-    def _capsule(self) -> Capsule:
-        return Capsule(self.pos.copy(), self.half_h, self.radius)
-
-
-    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
-
-
-    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
-        wish = forward * (self.input["f"] - self.input["b"]) + right * (
-            self.input["r"] - self.input["l"]
 
     def update(
         self, dt: float, forward: np.ndarray, right: np.ndarray
     ) -> None:
-        main
-        main
+        """Advance the controller by ``dt`` seconds."""
+
         wish = (
-            forward * (self.input["f"] - self.input["b"]) +
             forward * (self.input["f"] - self.input["b"])
             + right * (self.input["r"] - self.input["l"])
-        main
         )
         wish[1] = 0.0
-        n = np.linalg.norm(wish)
-
-        if n > 1e-6:
-            wish /= n
-
-
+        n = float(np.linalg.norm(wish))
         if n > 1e-6:
             wish /= n
         target = self.max_speed * (
             SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
-
-        wish = wish / n if n > 1e-6 else wish
-
-        
-        target = self.max_speed * (1.6 if self.input["sprint"] else 1.0)
-        main
-        main
-
-        target = self.max_speed * (
-            SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
-        )
-
-
-        main
-        main
-        main
-        hv = self.vel.copy()
-        hv[1] = 0.0
-        self.vel += (wish * target - hv) * min(
-            1.0, (50.0 if self.on_ground else 10.0) * dt
-        main
         )
         hv = self.vel.copy()
         hv[1] = 0.0
         accel = 50.0 if self.on_ground else 10.0
         self.vel += (wish * target - hv) * min(1.0, accel * dt)
-        main
+
         self.vel[1] -= self.g * dt
         if self.on_ground and self.input["jump"]:
             self.vel[1] = self.jump_speed
@@ -262,39 +84,27 @@ class PlayerControllerCapsule:
         off, ground = resolve_capsule_world(cap, self.world)
         self.pos += off
         self.on_ground = ground
-        if ground and self.vel[1] < 0:
+        if ground and self.vel[1] < 0.0:
             self.vel[1] = 0.0
 
         if np.allclose(off, 0.0, atol=1e-6) and (
-          
-            self.input["f"] or self.input["l"] or self.input["r"] or self.input["b"]
-
             self.input["f"]
             or self.input["b"]
             or self.input["l"]
             or self.input["r"]
-        main
         ):
+            cap.center = self.pos.copy()
             cap.center[1] += self.step_height
             off2, ground2 = resolve_capsule_world(cap, self.world)
             if not np.allclose(off2, 0.0, atol=1e-6):
-                ground = ground or ground2
-
-            self.pos = cap.center
-            self.on_ground = ground
-            if ground and self.vel[1] < 0:
-                self.vel[1] = 0.0
-
-        self.pos = cap.center
-        self.on_ground = ground
-        if ground and self.vel[1] < 0.0:
-            self.vel[1] = 0.0
+                self.pos = cap.center + off2
+                self.on_ground = ground or ground2
+                if self.on_ground and self.vel[1] < 0.0:
+                    self.vel[1] = 0.0
 
 
-
-import builtins as _builtins
-
-_builtins.get_horizontal_speed = get_horizontal_speed  # type: ignore[attr-defined]
-_builtins.SPRINT_SPEED_MULTIPLIER = SPRINT_SPEED_MULTIPLIER  # type: ignore[attr-defined]
-        main
-        main
+__all__ = [
+    "PlayerControllerCapsule",
+    "SPRINT_SPEED_MULTIPLIER",
+    "get_horizontal_speed",
+]

--- a/src/physics_cpp/capsule_voxel_sat.hpp
+++ b/src/physics_cpp/capsule_voxel_sat.hpp
@@ -1,15 +1,10 @@
 #pragma once
 #include "capsule.hpp"
 #include "aabb.hpp"
+#include "vec3.hpp"
 
-inline Vec3 closestPointOnAABB(const Vec3& p, const Vec3& mn, const Vec3& mx) {
-    return clamp(p, mn, mx);
-}
-
-inline Vec3 closestPointOnSegment(const Vec3& p, const Vec3& a, const Vec3& b) {
-    Vec3 ab = b - a;
-// Epsilon value to avoid division by zero in floating point calculations
 constexpr float DIVISION_EPSILON = 1e-9f;
+
 inline Vec3 closestPointOnAABB(const Vec3& p, const Vec3& mn, const Vec3& mx) {
     return clamp(p, mn, mx);
 }
@@ -22,8 +17,13 @@ inline Vec3 closestPointOnSegment(const Vec3& p, const Vec3& a, const Vec3& b) {
     return a + ab * t;
 }
 
-inline bool capsuleBoxPenetration(const Capsule& cap, const Vec3& mn, const Vec3& mx,
-                                  Vec3& normal, float& penetration) {
+inline bool capsuleBoxPenetration(
+    const Capsule& cap,
+    const Vec3& mn,
+    const Vec3& mx,
+    Vec3& normal,
+    float& penetration
+) {
     Vec3 box_center = (mn + mx) * 0.5f;
     Vec3 q_seg = closestPointOnSegment(box_center, cap.segA(), cap.segB());
     Vec3 q_box = closestPointOnAABB(q_seg, mn, mx);
@@ -46,3 +46,4 @@ inline Vec3 resolveCapsuleWorld(Capsule& cap) {
     }
     return off;
 }
+

--- a/src/physics_cpp/vec3.hpp
+++ b/src/physics_cpp/vec3.hpp
@@ -12,16 +12,15 @@ struct Vec3 {
     Vec3& operator+=(const Vec3& o) { x += o.x; y += o.y; z += o.z; return *this; }
 };
 
-inline float dot(const Vec3& a, const Vec3& b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
+inline float dot(const Vec3& a, const Vec3& b) {
+    return a.x * b.x + a.y * b.y + a.z * b.z;
+}
+
 inline float length(const Vec3& v) { return std::sqrt(dot(v, v)); }
 
 inline Vec3 normalize(const Vec3& v) {
     float len = length(v);
-// Returns the normalized vector, or Vec3::Up if the input is zero-length.
-inline Vec3 normalize(const Vec3& v) {
-    float len = length(v);
-    // Fallback to Up vector if length is zero to avoid division by zero.
-    return (len > 1e-9f) ? v * (1.0f / len) : Vec3::Up;
+    return len > 1e-9f ? v * (1.0f / len) : Vec3(0.0f, 1.0f, 0.0f);
 }
 
 inline Vec3 clamp(const Vec3& v, const Vec3& mn, const Vec3& mx) {
@@ -34,3 +33,4 @@ inline Vec3 clamp(const Vec3& v, const Vec3& mn, const Vec3& mx) {
         clampf(v.z, mn.z, mx.z)
     );
 }
+

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -1,101 +1,93 @@
+import ctypes
+import subprocess
+from pathlib import Path
 
-import pytest
 import numpy as np
+import pytest
 
-try:  # The player controller module is currently broken; skip tests if import fails.
+try:
     from src.physics.player_controller_capsule import (
         PlayerControllerCapsule,
         SPRINT_SPEED_MULTIPLIER,
         get_horizontal_speed,
     )
-except (ImportError, ModuleNotFoundError):  # pragma: no cover - skip if module cannot be imported
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
     pytest.skip(
         "player_controller_capsule module unavailable",
         allow_module_level=True,
     )
-
-import ctypes
-import subprocess
-from pathlib import Path
-
-import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 LIB_PATH = Path(__file__).with_name("physics_cpp.so")
 
 if not LIB_PATH.exists():
     src = ROOT / "src/physics_cpp/physics_c_api.cpp"
-    subprocess.check_call([
-        "g++", "-std=c++17", "-shared", "-fPIC", str(src),
-        "-I" + str(ROOT / "src/physics_cpp"), "-o", str(LIB_PATH)
-    raise FileNotFoundError(
-        f"Required shared library {LIB_PATH} not found. Please build it before running tests."
-    )
+    try:
+        subprocess.check_call(
+            [
+                "g++",
+                "-std=c++17",
+                "-shared",
+                "-fPIC",
+                str(src),
+                "-I" + str(ROOT / "src/physics_cpp"),
+                "-o",
+                str(LIB_PATH),
+            ]
+        )
+    except subprocess.CalledProcessError as exc:  # pragma: no cover
+        raise RuntimeError("failed to build physics_cpp.so") from exc
 
 lib = ctypes.CDLL(str(LIB_PATH))
 
+
 class Vec3(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_float), ("y", ctypes.c_float), ("z", ctypes.c_float)]
+    _fields_ = [
+        ("x", ctypes.c_float),
+        ("y", ctypes.c_float),
+        ("z", ctypes.c_float),
+    ]
+
 
 class Capsule(ctypes.Structure):
-    _fields_ = [("center", Vec3), ("half_height", ctypes.c_float), ("radius", ctypes.c_float)]
+    _fields_ = [
+        ("center", Vec3),
+        ("half_height", ctypes.c_float),
+        ("radius", ctypes.c_float),
+    ]
 
-lib.capsule_box_penetration.argtypes = [ctypes.POINTER(Capsule), Vec3, Vec3, ctypes.POINTER(Vec3), ctypes.POINTER(ctypes.c_float)]
+
+lib.capsule_box_penetration.argtypes = [
+    ctypes.POINTER(Capsule),
+    Vec3,
+    Vec3,
+    ctypes.POINTER(Vec3),
+    ctypes.POINTER(ctypes.c_float),
+]
 lib.capsule_box_penetration.restype = ctypes.c_int
 
-def test_capsule_box_penetration():
+
+def test_capsule_box_penetration() -> None:
     cap = Capsule(Vec3(0.0, 1.2, 0.0), 0.9, 0.3)
     mn = Vec3(-0.5, -0.5, -0.5)
     mx = Vec3(0.5, 0.5, 0.5)
     n = Vec3()
     pen = ctypes.c_float()
-    hit = lib.capsule_box_penetration(ctypes.byref(cap), mn, mx, ctypes.byref(n), ctypes.byref(pen))
+    hit = lib.capsule_box_penetration(
+        ctypes.byref(cap), mn, mx, ctypes.byref(n), ctypes.byref(pen)
+    )
     assert hit == 1
     assert pen.value > 0
     assert abs(n.y) <= 1.0
 
-import numpy as np
-
-
-        main
-from src.physics.player_controller_capsule import (
-    PlayerControllerCapsule,
-    SPRINT_SPEED_MULTIPLIER,
-    get_horizontal_speed,
-)
-
-
-
-from src.physics import (
-    SPRINT_SPEED_MULTIPLIER,
-    get_horizontal_speed,
-)
-from src.physics.player_controller_capsule import PlayerControllerCapsule
-        main
-
-SPRINT_SPEED_MULTIPLIER = 1.6
-
-
-def get_horizontal_speed(player):
-    return float(np.linalg.norm(player.vel[[0, 2]]))
-        main
-
-
-def get_horizontal_speed(player: PlayerControllerCapsule) -> float:
-    return float(np.linalg.norm(player.vel[[0, 2]]))
-
-
-SPRINT_SPEED_MULTIPLIER = 1.6
-        main
-
 
 class FlatWorld:
-    def get_block_at_world_position(self, x, y, z):
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
         return 1 if y < 0 else 0
 
 
 class StepWorld:
-    def get_block_at_world_position(self, x, y, z):
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
         if y < 0:
             return 1
         if 0 <= y < 1 and 1 <= x < 2:
@@ -103,9 +95,11 @@ class StepWorld:
         return 0
 
 
-def test_jump_and_land():
+def test_jump_and_land() -> None:
     world = FlatWorld()
-    player = PlayerControllerCapsule(world, np.array([0.0, 1.2, 0.0], dtype=np.float32))
+    player = PlayerControllerCapsule(
+        world, np.array([0.0, 1.2, 0.0], dtype=np.float32)
+    )
     forward = np.array([0.0, 0.0, 1.0], dtype=np.float32)
     right = np.array([1.0, 0.0, 0.0], dtype=np.float32)
 
@@ -128,9 +122,11 @@ def test_jump_and_land():
     assert player.vel[1] == 0.0
 
 
-def test_step_climb():
+def test_step_climb() -> None:
     world = StepWorld()
-    player = PlayerControllerCapsule(world, np.array([0.0, 1.2, 0.0], dtype=np.float32))
+    player = PlayerControllerCapsule(
+        world, np.array([0.0, 1.2, 0.0], dtype=np.float32)
+    )
     forward = np.array([1.0, 0.0, 0.0], dtype=np.float32)
     right = np.array([0.0, 0.0, 1.0], dtype=np.float32)
 
@@ -142,9 +138,11 @@ def test_step_climb():
     assert player.on_ground
 
 
-def test_sprint_speed_limit():
+def test_sprint_speed_limit() -> None:
     world = FlatWorld()
-    player = PlayerControllerCapsule(world, np.array([0.0, 1.2, 0.0], dtype=np.float32))
+    player = PlayerControllerCapsule(
+        world, np.array([0.0, 1.2, 0.0], dtype=np.float32)
+    )
     forward = np.array([1.0, 0.0, 0.0], dtype=np.float32)
     right = np.array([0.0, 0.0, 1.0], dtype=np.float32)
 
@@ -156,34 +154,10 @@ def test_sprint_speed_limit():
     speed = get_horizontal_speed(player)
     assert speed <= player.max_speed + 1e-3
 
-
-
-    speed = get_horizontal_speed(player)
-    assert speed <= player.max_speed + 1e-3
-
-
-
-
-    speed = get_horizontal_speed(player)
-    assert speed <= player.max_speed + 1e-3
-
-
-    player.set_input({"sprint": 1})
-    for _ in range(20):
-        player.update(0.1, forward, right)
-
-        main
-    speed = get_horizontal_speed(player)
-    assert speed <= player.max_speed + 1e-3
-
-        main
-        main
-        main
     player.set_input({"f": 1, "sprint": 1})
     for _ in range(20):
         player.update(0.1, forward, right)
-        main
+
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-         main


### PR DESCRIPTION
## Summary
- rebuild capsule player controller and helpers
- clean player controller test with proper imports and physics_cpp.so build handling
- replace broken C++ collision helpers used by tests

## Testing
- `flake8 src/physics/__init__.py src/physics/capsule.py src/physics/capsule_voxel_sat.py src/physics/player_controller_capsule.py tests/test_player_controller_capsule.py`
- `mypy --config-file /dev/null --explicit-package-bases src/physics/__init__.py src/physics/capsule.py src/physics/capsule_voxel_sat.py src/physics/player_controller_capsule.py tests/test_player_controller_capsule.py`
- `npx eslint .` *(fails: SyntaxError: Unexpected string)*
- `pytest` *(fails: tests/test_capsule_ground.py IndentationError)*
- `pytest tests/test_player_controller_capsule.py`


------
https://chatgpt.com/codex/tasks/task_e_68a174e5f8e0832d8718ed094988612d