### PR TITLE
Simplify ESLint configuration

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,118 +1,27 @@
-
 const js = require('@eslint/js');
+const globals = require('globals');
 
-
-        main
 module.exports = [
   {
-
-    ignores: ['node_modules/**'],
-
     ignores: [
-
-
-
       '**/build/**',
-
-
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-  }
-
-
-      'assets/**', 'build_ci_sanity/**', 'cmake/**',
-      'docs/**', 'shaders/**', 'shaders_vk/**',
-      'tools/**'
-    ]
-
-        main
-        main
-        main
-        main
-      'assets/**',
-      'build_ci_sanity/**',
-      'cmake/**',
+      'node_modules/**',
       'docs/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
+      'assets/**',
       'tests/**',
       'src/**',
-      'eslint.config.js',
       'apps/**',
       'scripts/**',
-
-      'node_modules/**'
-
-
-      'node_modules/**'
-
-
-      'scripts/**'
-    ]
-
-
-      'scripts/**'
-        main
-        main
-    ]
-
     ],
-        main
-       main
-        main
-        main
   },
-
-  js.configs.recommended
-
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-
-      globals: { ...globals.node, ...globals.es2021 }
-
-      globals: {
-        ...globals.node,
-        ...globals.es2021,
-      },
-
+      globals: { ...globals.node, ...globals.es2021 },
     },
-
-    rules: {
-      'no-unused-vars': 'warn',
-      semi: ['error', 'always']
-    }
-  }
-
-
-    rules: {
-      'no-unused-vars': 'warn',
-      semi: ['error', 'always'],
-    },
+    rules: { 'no-unused-vars': 'warn', semi: ['error', 'always'] },
   },
-
-        main
-    },
-    rules: {},
-  },
-        main
-        main
-        main
-        main
 ];
 


### PR DESCRIPTION
## Summary
- replace existing ESLint config with minimal commonjs setup using @eslint/js and globals

## Testing
- `npx eslint .`
- `pytest` *(fails: IndentationError in tests and src)*
- `mypy` *(fails: mypy.ini duplicate option)*

------
https://chatgpt.com/codex/tasks/task_e_68a178642a94832dbf8b25bb252d8003