### PR TITLE
Clean up capsule ground test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -1,9 +1,12 @@
-
 import os
 import sys
-import pytest
 import importlib
+import ctypes
+import subprocess
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from src.physics.capsule import Capsule
@@ -17,36 +20,58 @@ except (ImportError, ModuleNotFoundError):  # pragma: no cover - skip if module 
     pytest.skip("capsule_voxel_sat module unavailable", allow_module_level=True)
 resolve_capsule_world = capsule_voxel_sat.resolve_capsule_world
 
-import ctypes
-import subprocess
-import pytest
-from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 LIB_PATH = Path(__file__).with_name("physics_cpp.so")
-         main
 
 if not LIB_PATH.exists():
     src = ROOT / "src/physics_cpp/physics_c_api.cpp"
-    subprocess.check_call([
-        "g++", "-std=c++17", "-shared", "-fPIC", str(src),
-        "-I" + str(ROOT / "src/physics_cpp"), "-o", str(LIB_PATH)
-    ])
+    subprocess.check_call(
+        [
+            "g++",
+            "-std=c++17",
+            "-shared",
+            "-fPIC",
+            str(src),
+            "-I",
+            str(ROOT / "src/physics_cpp"),
+            "-o",
+            str(LIB_PATH),
+        ]
+    )
 
 lib = ctypes.CDLL(str(LIB_PATH))
 
+
 class Vec3(ctypes.Structure):
-    _fields_ = [("x", ctypes.c_float), ("y", ctypes.c_float), ("z", ctypes.c_float)]
+    _fields_ = [
+        ("x", ctypes.c_float),
+        ("y", ctypes.c_float),
+        ("z", ctypes.c_float),
+    ]
 
-class Capsule(ctypes.Structure):
-    _fields_ = [("center", Vec3), ("half_height", ctypes.c_float), ("radius", ctypes.c_float)]
 
-lib.resolve_capsule_ground.argtypes = [ctypes.POINTER(Capsule), ctypes.POINTER(Vec3)]
+class CCapsule(ctypes.Structure):
+    _fields_ = [
+        ("center", Vec3),
+        ("half_height", ctypes.c_float),
+        ("radius", ctypes.c_float),
+    ]
+
+
+lib.resolve_capsule_ground.argtypes = [
+    ctypes.POINTER(CCapsule),
+    ctypes.POINTER(Vec3),
+]
 lib.resolve_capsule_ground.restype = ctypes.c_int
 
 
-def test_capsule_ground_collision():
+class DummyWorld:
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
+        return 1 if y < 0.0 else 0
 
+
+def test_capsule_ground_collision() -> None:
     world = DummyWorld()
     cap = Capsule(
         center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
@@ -56,20 +81,9 @@ def test_capsule_ground_collision():
     off, ground = resolve_capsule_world(cap, world)
     assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
 
-
-    cap = Capsule(Vec3(0.0, 0.2, 0.0), 0.9, 0.3)
+    c_cap = CCapsule(Vec3(0.0, 0.2, 0.0), 0.9, 0.3)
     off = Vec3()
-    grounded = lib.resolve_capsule_ground(ctypes.byref(cap), ctypes.byref(off))
+    grounded = lib.resolve_capsule_ground(ctypes.byref(c_cap), ctypes.byref(off))
     assert grounded == 1
-    assert abs(cap.center.y - 1.2) < 1e-4
+    assert abs(c_cap.center.y - 1.2) < 1e-4
     assert off.y == pytest.approx(1.0, abs=1e-4)
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- fix capsule ground test by removing stray text, adding world stub, and compiling C++ helper

## Testing
- `npx eslint .` *(fails: SyntaxError: Unexpected string)*
- `mypy .` *(fails: option 'explicit_package_bases' ... already exists)*
- `pytest` *(fails: SyntaxError in tests/test_player_controller_capsule.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1789b06a0832da41c0cb0e891f6c1