### PR TITLE
Clean up mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
 exclude = ^src/physics/
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-        main


### PR DESCRIPTION
## Summary
- remove duplicate `explicit_package_bases` entry from mypy config
- drop stray trailing text in mypy.ini

## Testing
- `npx eslint .` *(fails: SyntaxError: Unexpected string)*
- `pytest` *(fails: IndentationError, SyntaxError during test collection)*
- `mypy .` *(fails: Unexpected indent in tests/test_capsule_ground.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a1789e40ac832d9190951dd800bafc