### PR TITLE
chore: clean up mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,3 @@ ignore_missing_imports = True
 
 exclude = ^src/physics/
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-        main


### PR DESCRIPTION
## Summary
- remove duplicate explicit_package_bases and stray entry in mypy.ini

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: IndentationError & SyntaxError in tests)*
- `npx eslint .` *(fails: SyntaxError: Unexpected string in eslint.config.cjs)*
- `mypy .` *(fails: Unexpected indent in tests/test_capsule_ground.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a17929aa5c832d8b35304c41700e06