### PR TITLE
Remove stray main line from physics module

### DIFF
--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -34,4 +34,3 @@ def get_horizontal_speed(player: Any) -> float:
 
 
 __all__ = ["SPRINT_SPEED_MULTIPLIER", "get_horizontal_speed"]
-        main


### PR DESCRIPTION
## Summary
- fix physics package init by removing erroneous trailing `main` line so `__all__` is final statement

## Testing
- `pytest` *(fails: SyntaxError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: duplicate option explicit_package_bases in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a1792a9870832d8a7febb0d44d73ab