### PR TITLE
refactor: simplify eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,118 +1,36 @@
-
 const js = require('@eslint/js');
+const globals = require('globals');
 
-
-        main
 module.exports = [
   {
-
-    ignores: ['node_modules/**'],
-
     ignores: [
-
-
-
-      '**/build/**',
-
-
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-  }
-
-
-      'assets/**', 'build_ci_sanity/**', 'cmake/**',
-      'docs/**', 'shaders/**', 'shaders_vk/**',
-      'tools/**'
-    ]
-
-        main
-        main
-        main
-        main
-      'assets/**',
+      'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
+      'assets/**',
       'shaders/**',
       'shaders_vk/**',
       'tools/**',
       'tests/**',
       'src/**',
-      'eslint.config.js',
       'apps/**',
-      'scripts/**',
-
-      'node_modules/**'
-
-
-      'node_modules/**'
-
-
       'scripts/**'
     ]
-
-
-      'scripts/**'
-        main
-        main
-    ]
-
-    ],
-        main
-       main
-        main
-        main
   },
-
-  js.configs.recommended
-
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-
-      globals: { ...globals.node, ...globals.es2021 }
-
       globals: {
         ...globals.node,
-        ...globals.es2021,
-      },
-
+        ...globals.es2021
+      }
     },
-
     rules: {
       'no-unused-vars': 'warn',
       semi: ['error', 'always']
     }
   }
-
-
-    rules: {
-      'no-unused-vars': 'warn',
-      semi: ['error', 'always'],
-    },
-  },
-
-        main
-    },
-    rules: {},
-  },
-        main
-        main
-        main
-        main
 ];
-


### PR DESCRIPTION
## Summary
- replace broken eslint.config.cjs with clean array-based configuration

## Testing
- `npx eslint .`
- `pytest` *(fails: unexpected indent in tests; '[' never closed)*
- `mypy .` *(fails: duplicate option explicit_package_bases)*

------
https://chatgpt.com/codex/tasks/task_e_68a1792c059c832d904cf13a9da93935