### PR TITLE
Add quickstart guide for setup and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repo contains:
 - GPU blockizer compute shader (`shaders_vk/ai/blockize.comp.glsl`)
 - Self-contained smoke test + CTest
 - GitHub Actions CI (Linux & Windows) that installs Vulkan SDK, builds, tests, and publishes artifacts
+See [Quickstart guide](docs/QUICKSTART.md) for setup and usage.
 
 ## Local build
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -7,7 +7,8 @@ This guide walks you through cloning the repository, running basic smoke tests, 
 Clone the repository and build it with CMake:
 
 ```bash
-git clone <repo-url>
+# Replace <your-repository-url> with the URL of your fork or the main repository on GitHub
+git clone <your-repository-url>
 cd VULKEN-3D-WORLD
 cmake -S . -B build -G Ninja -DENABLE_IMGUI_OVERLAY=ON -DVOXELVK_ENABLE_CUDA=OFF -DVOXELVK_ENABLE_TENSORRT=OFF
 cmake --build build -j

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,47 @@
+# Quickstart Guide
+
+This guide walks you through cloning the repository, running basic smoke tests, and launching the demo viewer.
+
+## 1. Repository setup
+
+Clone the repository and build it with CMake:
+
+```bash
+git clone <repo-url>
+cd VULKEN-3D-WORLD
+cmake -S . -B build -G Ninja -DENABLE_IMGUI_OVERLAY=ON -DVOXELVK_ENABLE_CUDA=OFF -DVOXELVK_ENABLE_TENSORRT=OFF
+cmake --build build -j
+```
+
+Set up the Python environment for utilities and tests:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 2. Run smoke tests
+
+After building, execute the bundled smoke tests:
+
+```bash
+ctest --test-dir build --output-on-failure
+```
+
+For Python-based checks, run:
+
+```bash
+pytest
+```
+
+## 3. Launch the viewer
+
+Build and run the demo viewer:
+
+```bash
+cmake --build build --target demo_window
+./build/demo_window
+```
+
+The window should appear rendering the sample scene.


### PR DESCRIPTION
## Summary
- document repo setup, smoke tests, and demo viewer in a new QUICKSTART guide
- link quickstart from README

## Testing
- `pytest -q` *(fails: IndentationError in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a172a182e0832d815512b4eb0692db