### PR TITLE
Exclude physics package from mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 explicit_package_bases = True
+exclude = ^src/physics/


### PR DESCRIPTION
## Summary
- add exclude rule for src/physics in mypy config
- ensure mypy options appear only once and remove stray main line

## Testing
- `pytest`
- `npx eslint . --max-warnings=0`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a27c9068f8832db90b01c93af715cc