### PR TITLE
chore: streamline eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,4 +1,14 @@
 /* global require, module */
 const js = require('@eslint/js');
 
-module.exports = [{ ignores: ['node_modules/**'], languageOptions: { ecmaVersion: 2021, sourceType: 'script' }, rules: {} }, js.configs.recommended];
+module.exports = [
+  {
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+    },
+    rules: {},
+  },
+  js.configs.recommended,
+];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,34 +1,4 @@
+/* global require, module */
 const js = require('@eslint/js');
-const globals = require('globals');
 
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-      '**/build/**',
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'src/**',
-      'apps/**',
-      'scripts/**'
-    ]
-  },
-  {
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-];
+module.exports = [{ ignores: ['node_modules/**'], languageOptions: { ecmaVersion: 2021, sourceType: 'script' }, rules: {} }, js.configs.recommended];


### PR DESCRIPTION
## Summary
- simplify ESLint setup to use @eslint/js recommended config

## Testing
- `pytest`
- `npx eslint eslint.config.cjs`
- `mypy --exclude 'src/physics/' .`


------
https://chatgpt.com/codex/tasks/task_e_68a27c92157c832d96e835cc83eb16ff