### PR TITLE
Configure mypy to skip physics module

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-exclude = ^src/physics/
+exclude = src/physics/.*
 explicit_package_bases = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 ignore_missing_imports = True
+exclude = ^src/physics/
 explicit_package_bases = True


### PR DESCRIPTION
## Summary
- ignore mypy checks in `src/physics` by updating `mypy.ini`

## Testing
- `npx eslint .`
- `pytest`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a27df07c1c832da432df557f4f3ff5