### PR TITLE
Use optional NumPy imports in tests

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 explicit_package_bases = True
+exclude = src/physics/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,3 @@
 [mypy]
 ignore_missing_imports = True
 explicit_package_bases = True
-exclude = src/physics/

--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,76 +1,46 @@
-"""Axis-aligned bounding box helpers for collision tests."""
+"""Axis-aligned bounding box utilities."""
 
-
-
-
-
-from __future__ import annotations
-
-        main
-        main
-import numpy as np
-        main
 from dataclasses import dataclass
-import numpy as np
 
 import numpy as np
-
 from numpy.typing import NDArray
 
 
 @dataclass
 class AABB:
+    """Simple axis-aligned bounding box.
 
-    center: np.ndarray
-    half: np.ndarray
-
-    @property
+    Parameters
+    ----------
+    center:
+        The center of the box.
+    half:
+        Half extents of the box along each axis.
+    """
 
     center: NDArray[np.float32]
     half: NDArray[np.float32]
 
     @property
-
     def min(self) -> NDArray[np.float32]:
+        """Minimum corner of the box."""
+
         return self.center - self.half
 
     @property
-
-
-
-
-
     def max(self) -> NDArray[np.float32]:
-
-        main
-        main
-        main
-        main
-    def min(self) -> np.ndarray:
-        return self.center - self.half
-
-    @property
-    def max(self) -> np.ndarray:
-
-        return self.center + self.half
-
-    def moved(self, delta: np.ndarray) -> "AABB":
-
         """Maximum corner of the box."""
 
-
-
-        main
-        main
-        main
-        main
         return self.center + self.half
 
     def moved(self, delta: NDArray[np.float32]) -> "AABB":
-        main
+        """Return a translated copy of this box."""
+
         return AABB(self.center + delta, self.half)
 
     def overlap_aabb(self, other: "AABB") -> bool:
+        """Check if this box overlaps another."""
+
         return not (
             self.max[0] <= other.min[0]
             or self.min[0] >= other.max[0]

--- a/tests/test_capsule_properties.py
+++ b/tests/test_capsule_properties.py
@@ -1,5 +1,4 @@
 import pytest
-
 np = pytest.importorskip("numpy")
 from src.physics.capsule import Capsule
 

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -1,4 +1,5 @@
 import pytest
+np = pytest.importorskip("numpy")
 
 pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -1,6 +1,5 @@
 import pytest
 np = pytest.importorskip("numpy")
-
 pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,

--- a/tests/test_rle.py
+++ b/tests/test_rle.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
+np = pytest.importorskip("numpy")
+import numpy.typing as npt
 
 if TYPE_CHECKING:
-    import numpy as np
-else:  # pragma: no cover - skip if numpy is missing
-    np = pytest.importorskip("numpy")
+    import numpy as _np
 
 from src.world.rle import rle_encode, rle_decode
 
 
-def _roundtrip(arr: np.ndarray) -> None:
+def _roundtrip(arr: npt.NDArray[_np.uint8]) -> None:
     vals, counts, shape = rle_encode(arr)
     decoded = rle_decode(vals, counts, shape)
     assert decoded.shape == arr.shape


### PR DESCRIPTION
## Summary
- replace direct NumPy imports in tests with `pytest.importorskip`
- add optional NumPy import in chunk store test
- clean up AABB module and adjust mypy config to satisfy type checks

## Testing
- `pytest -q`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a27df18b00832d9b99bb96cb341cf6