### PR TITLE
Add DummyWorld to capsule ground test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -1,6 +1,29 @@
+import numpy as np
 import pytest
 
 pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
+
+import importlib
+
+from src.physics.capsule import Capsule
+
+
+class DummyWorld:
+    def get_block_at_world_position(self, x, y, z):
+        return 1 if y < 0 else 0
+
+
+def test_capsule_ground_collision():
+    world = DummyWorld()
+    capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
+    resolve_capsule_world = capsule_voxel_sat.resolve_capsule_world
+    cap = Capsule(
+        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
+        half_height=0.9,
+        radius=0.3,
+    )
+    off, ground = resolve_capsule_world(cap, world)
+    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -7,7 +7,16 @@ pytest.skip(
 )
 
 import importlib
+import importlib
 
+try:
+    capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
+except ImportError:
+    import pytest
+    pytest.skip(
+        "capsule ground collision tests require native extensions not built in CI",
+        allow_module_level=True,
+    )
 from src.physics.capsule import Capsule
 
 

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -27,7 +27,10 @@ class DummyWorld:
 
 def test_capsule_ground_collision():
     world = DummyWorld()
-    capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
+    try:
+        capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
+    except ImportError:
+        pytest.skip("Native extension 'src.physics.capsule_voxel_sat' is missing, skipping test.")
     resolve_capsule_world = capsule_voxel_sat.resolve_capsule_world
     cap = Capsule(
         center=np.array([0.0, 0.2, 0.0], dtype=np.float32),


### PR DESCRIPTION
## Summary
- add a simple DummyWorld helper for capsule-ground collision test
- dynamically import collision resolver to keep test skipped when native extensions are missing

## Testing
- `mypy tests/test_capsule_ground.py`
- `pytest`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a27df5caac832d82ef9400f29a0fa9