### PR TITLE
Clean up stray main lines in tests and configs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,34 +1,10 @@
-
-
-
 const js = require('@eslint/js');
 const globals = require('globals');
 
-        main
-        main
 module.exports = [
   js.configs.recommended,
   {
-
-    ignores: ['**/*'],
-  },
-
     ignores: [
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-
       '**/build/**',
       'node_modules/**',
       'build_ci_sanity/**',
@@ -54,7 +30,5 @@ module.exports = [
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
-        main
   }
-        main
 ];

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,9 +2,3 @@
 ignore_missing_imports = True
 exclude = ^src/physics/
 explicit_package_bases = True
-
-
-
-explicit_package_bases = True
-        main
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,49 +1,21 @@
-
-import numpy as np
-
-"""Minimal capsule representation for tests."""
-
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
+import numpy as np
+from numpy.typing import NDArray
+
+"""Minimal capsule representation for tests."""
 
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule represented by a center point and radius.
-
-    Parameters
-    ----------
-    center:
-        Capsule midpoint ``(x, y, z)``.
-    half_height:
-        Distance from the center to the center of each spherical cap.
-    radius:
-        Radius of the capsule.
-    """
-
-    center: np.ndarray
-
     """Simple vertical capsule defined by its center, half-height, and radius."""
 
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
         return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
@@ -55,4 +27,3 @@ class Capsule:
 
 
 __all__ = ["Capsule"]
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -11,7 +11,7 @@ from numpy.typing import NDArray
 class Capsule:
     """Simple vertical capsule defined by its center, half-height, and radius."""
 
-    center: NDArray[np.float32]
+    center: NDArray[np.float32, Literal[3]]
     half_height: float
     radius: float
 

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -133,5 +133,3 @@ pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
-        main
-        main

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -56,4 +56,3 @@ pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,
 )
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- remove erroneous `main` tokens from several test modules
- simplify physics Capsule implementation for tests
- rebuild ESLint and mypy configs

## Testing
- `pytest`
- `npx eslint eslint.config.cjs --format json`
- `mypy src/physics/capsule.py tests/test_chunk_store_cpp.py tests/test_capsule_properties.py tests/test_rle.py tests/test_worldgen_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68a28ac7f758832dac8fd3dac5c2f29b