### PR TITLE
Clean Capsule dataclass and fix test scaffolding

### DIFF
--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,58 +1,35 @@
-
-import numpy as np
+from __future__ import annotations
 
 """Minimal capsule representation for tests."""
 
-from __future__ import annotations
-
-        main
 from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule represented by a center point and radius.
-
-    Parameters
-    ----------
-    center:
-        Capsule midpoint ``(x, y, z)``.
-    half_height:
-        Distance from the center to the center of each spherical cap.
-    radius:
-        Radius of the capsule.
-    """
-
-    center: np.ndarray
-
-    """Simple vertical capsule defined by its center, half-height, and radius."""
+    """Simple vertical capsule defined by its center,
+    half-height, and radius."""
 
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
-        return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
+        return self.center + np.array(
+            [0.0, self.half_height, 0.0], dtype=np.float32
+        )
 
     @property
     def seg_b(self) -> NDArray[np.float32]:
         """Center of the bottom spherical cap."""
-        return self.center - np.array([0.0, self.half_height, 0.0], dtype=np.float32)
+        return self.center - np.array(
+            [0.0, self.half_height, 0.0], dtype=np.float32
+        )
 
 
 __all__ = ["Capsule"]
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -12,7 +12,18 @@ from numpy.typing import NDArray
 class Capsule:
     """Simple vertical capsule defined by its center,
     half-height, and radius."""
+    """
+    Represents a simple vertical capsule defined by its center, half-height, and radius.
 
+    Parameters
+    ----------
+    center : numpy.ndarray of shape (3,)
+        The center of the capsule (midpoint between the two spherical caps), in 3D space.
+    half_height : float
+        Half the height of the cylindrical part of the capsule (distance from center to cap center).
+    radius : float
+        The radius of the spherical caps and the cylinder.
+    """
     center: NDArray[np.float32]
     half_height: float
     radius: float

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -133,5 +133,3 @@ pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
-        main
-        main

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -56,4 +56,3 @@ pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,
 )
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- refactor `Capsule` dataclass with clean seg_a/seg_b helpers
- remove stray placeholders from test modules to restore test execution

## Testing
- `python -m flake8 src/physics/capsule.py`
- `MYPYPATH=src python -m mypy --config-file=/tmp/mypy.ini --explicit-package-bases -m physics.capsule`
- `pytest`
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68a28acc16f8832d83cc44eb12381cd9