### PR TITLE
Clean up capsule voxel SAT helpers

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,3 @@ ignore_missing_imports = True
 exclude = ^src/physics/
 explicit_package_bases = True
 
-
-
-explicit_package_bases = True
-        main
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,58 +1,33 @@
-
-import numpy as np
-
 """Minimal capsule representation for tests."""
 
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule represented by a center point and radius.
-
-    Parameters
-    ----------
-    center:
-        Capsule midpoint ``(x, y, z)``.
-    half_height:
-        Distance from the center to the center of each spherical cap.
-    radius:
-        Radius of the capsule.
-    """
-
-    center: np.ndarray
-
-    """Simple vertical capsule defined by its center, half-height, and radius."""
+    """Vertical capsule defined by its center, half-height, and radius."""
 
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
+
         return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
 
     @property
     def seg_b(self) -> NDArray[np.float32]:
         """Center of the bottom spherical cap."""
+
         return self.center - np.array([0.0, self.half_height, 0.0], dtype=np.float32)
 
 
 __all__ = ["Capsule"]
-        main
+

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -64,7 +64,7 @@ def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
     return np.floor(mn).astype(int), np.floor(mx).astype(int)
 
 
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[NDArray[np.float32], bool]:
+def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> tuple[NDArray[np.float32], bool]:
     """Keep ``cap`` above solid blocks in ``world`` and report displacement and ground state."""
 
     off = np.zeros(3, dtype=np.float32)

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,14 +1,8 @@
-
-"""Collision helpers for capsule vs voxel world using SAT."""
-
-from typing import Any, Optional, Tuple, cast
-
-"""Collision helpers for a capsule against a voxel world using simple SAT tests."""
+"""Collision helpers for a capsule against a voxel world using SAT tests."""
 
 from __future__ import annotations
 
 from typing import Optional, Protocol, Tuple, cast
-        main
 
 import numpy as np
 from numpy.typing import NDArray
@@ -16,12 +10,6 @@ from numpy.typing import NDArray
 from .capsule import Capsule
 from .voxel_solid import is_solid
 
-
-
-def closest_point_on_aabb(
-    p: np.ndarray, mn: np.ndarray, mx: np.ndarray
-) -> np.ndarray:
-    """Return the closest point on an axis-aligned box to ``p``."""
 
 class WorldProtocol(Protocol):
     """Minimal protocol required from the voxel world used in tests."""
@@ -32,35 +20,26 @@ class WorldProtocol(Protocol):
 def closest_point_on_aabb(
     p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> NDArray[np.float32]:
-    """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
-        main
+    """Return the closest point on the axis-aligned box defined by ``mn`` and ``mx``."""
+
     return np.minimum(np.maximum(p, mn), mx)
 
 
 def closest_point_on_segment(
-
-    p: np.ndarray, a: np.ndarray, b: np.ndarray
-) -> np.ndarray:
-
     p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]
 ) -> NDArray[np.float32]:
-        main
     """Return the closest point on the segment ``ab`` to ``p``."""
+
     ab = b - a
     t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
     return a + np.clip(t, 0.0, 1.0) * ab
 
 
 def capsule_box_penetration(
-
-    cap: Capsule, mn: np.ndarray, mx: np.ndarray
-) -> Tuple[bool, Optional[np.ndarray], float]:
-    """Compute penetration of ``cap`` against an axis-aligned box."""
-
     cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
     """Check penetration of ``cap`` against an axis-aligned box."""
-        main
+
     box_center = (mn + mx) * 0.5
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
@@ -69,32 +48,26 @@ def capsule_box_penetration(
     pen = cap.radius - dist
     if pen > 0.0:
         normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-
-        return True, cast(np.ndarray, normal), float(pen)
-    return False, None, 0.0
-
-
-def resolve_capsule_world(
-    cap: Capsule, world: Any, max_iters: int = 8
-) -> Tuple[np.ndarray, bool]:
-    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
-    total_offset = np.zeros(3, dtype=np.float32)
-
         return True, cast(NDArray[np.float32], normal), float(pen)
     return False, None, 0.0
 
 
 def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
     """Return integer min/max voxel coordinates overlapped by ``cap``."""
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+
+    mn = cap.center - np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
+    mx = cap.center + np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
     return np.floor(mn).astype(int), np.floor(mx).astype(int)
 
 
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[np.ndarray, bool]:
-    """Very small helper used in tests to keep the capsule above solid blocks."""
+def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[NDArray[np.float32], bool]:
+    """Keep ``cap`` above solid blocks in ``world`` and report displacement and ground state."""
+
     off = np.zeros(3, dtype=np.float32)
-        main
     ground = False
     mn, mx = compute_capsule_voxel_bounds(cap)
     for y in range(mn[1], mx[1] + 1):
@@ -112,41 +85,6 @@ def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[np.ndarra
     return off, ground
 
 
-    for _ in range(max_iters):
-        mn = cap.center - np.array(
-            [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
-        )
-        mx = cap.center + np.array(
-            [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
-        )
-        bb_min = np.floor(mn).astype(int)
-        bb_max = np.floor(mx).astype(int)
-
-        max_pen = 0.0
-        hit_n: Optional[np.ndarray] = None
-        for y in range(bb_min[1] - 1, bb_max[1] + 2):
-            for z in range(bb_min[2] - 1, bb_max[2] + 2):
-                for x in range(bb_min[0] - 1, bb_max[0] + 2):
-                    bt = world.get_block_at_world_position(float(x), float(y), float(z))
-                    if not bt:
-                        continue
-                    mnv = np.array([x, y, z], dtype=np.float32)
-                    mxv = mnv + 1.0
-                    hit, n, pen = capsule_box_penetration(cap, mnv, mxv)
-                    if hit and pen > max_pen:
-                        max_pen, hit_n = pen, n
-        if max_pen <= 1e-6 or hit_n is None:
-            break
-        off = hit_n * max_pen
-        cap.center += off
-        total_offset += off
-        if hit_n is not None and hit_n[1] > 0.7:
-            ground = True
-
-    return total_offset, ground
-
-
-
 __all__ = [
     "WorldProtocol",
     "closest_point_on_aabb",
@@ -155,4 +93,4 @@ __all__ = [
     "compute_capsule_voxel_bounds",
     "resolve_capsule_world",
 ]
-        main
+

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,18 +1,13 @@
-
-        main
 """Utilities to query whether a voxel block type is solid."""
+
+from __future__ import annotations
 
 from typing import Dict
 
 
-# Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""
 
-class BlockType:
-    """Enumeration of built-in block types."""
-
-        main
     AIR = 0
 
 
@@ -21,15 +16,8 @@ BLOCK_PROPERTIES: Dict[int, dict] = {}
 
 
 def is_solid(block_type: int) -> bool:
-
-    """Return ``True`` if ``block_type`` should be considered solid."""
-    try:
-        props = BLOCK_PROPERTIES.get(block_type, {})
-        return bool(props.get("solid", block_type != BlockType.AIR))
-    except Exception:
-        return block_type != BlockType.AIR
-
     """Return ``True`` if ``block_type`` represents a solid block."""
+
     props = BLOCK_PROPERTIES.get(block_type)
     if props is None:
         return block_type != BlockType.AIR
@@ -37,4 +25,4 @@ def is_solid(block_type: int) -> bool:
 
 
 __all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]
-        main
+

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -133,5 +133,3 @@ pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
-        main
-        main

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -56,4 +56,3 @@ pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,
 )
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- remove stray `main` lines and duplicate helpers in `capsule_voxel_sat`
- simplify minimal `Capsule` and voxel solidity helpers
- tidy tests and config to run type checks

## Testing
- `pytest`
- `npx eslint .` *(fails: Unexpected token in eslint.config.cjs)*
- `mypy src/physics/capsule_voxel_sat.py src/physics/capsule.py src/physics/voxel_solid.py`

------
https://chatgpt.com/codex/tasks/task_e_68a28acebbbc832dad5ea29b017fe0cb