### PR TITLE
Refactor voxel solid utility

### DIFF
--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -16,7 +16,7 @@ BLOCK_PROPERTIES: Dict[int, dict] = {}
 def is_solid(block_type: int) -> bool:
     """Return ``True`` if ``block_type`` represents a solid block."""
     props = BLOCK_PROPERTIES.get(block_type)
-    if props is None:
+    if not props:
         return block_type != BlockType.AIR
     return bool(props.get("solid", block_type != BlockType.AIR))
 

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,18 +1,11 @@
-
-        main
 """Utilities to query whether a voxel block type is solid."""
 
 from typing import Dict
 
 
-# Adapt this to your engine's block registry
 class BlockType:
     """Enumeration of built-in block types."""
 
-class BlockType:
-    """Enumeration of built-in block types."""
-
-        main
     AIR = 0
 
 
@@ -21,14 +14,6 @@ BLOCK_PROPERTIES: Dict[int, dict] = {}
 
 
 def is_solid(block_type: int) -> bool:
-
-    """Return ``True`` if ``block_type`` should be considered solid."""
-    try:
-        props = BLOCK_PROPERTIES.get(block_type, {})
-        return bool(props.get("solid", block_type != BlockType.AIR))
-    except Exception:
-        return block_type != BlockType.AIR
-
     """Return ``True`` if ``block_type`` represents a solid block."""
     props = BLOCK_PROPERTIES.get(block_type)
     if props is None:
@@ -37,4 +22,3 @@ def is_solid(block_type: int) -> bool:
 
 
 __all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]
-        main


### PR DESCRIPTION
## Summary
- clean up voxel_solid module: remove duplicate BlockType class and redundant logic
- define single BlockType enum with AIR member
- simplify is_solid helper

## Testing
- `pytest` *(fails: IndentationError in tests)*
- `mypy src` *(fails: configuration error and unexpected indent in aabb.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `pytest tests/test_capsule_ground.py` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a28ad399bc832db1c85f414750b9b1