### PR TITLE
chore: clean eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -31,7 +31,7 @@ module.exports = [
     },
     rules: {
       'no-unused-vars': 'warn',
-      semi: ['error', 'always']
+      'semi': ['error', 'always']
     }
   }
 ];

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -4,31 +4,10 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-        main
-        main
 module.exports = [
   js.configs.recommended,
   {
-
-    ignores: ['**/*'],
-  },
-
     ignores: [
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-
       '**/build/**',
       'node_modules/**',
       'build_ci_sanity/**',
@@ -52,9 +31,7 @@ module.exports = [
     },
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
+      semi: ['error', 'always']
     }
-        main
   }
-        main
 ];


### PR DESCRIPTION
## Summary
- prune stray main lines in ESLint config
- consolidate ignore paths into single list

## Testing
- `node -e "require('./eslint.config.cjs')"`
- `npx eslint .`
- `pytest` *(fails: IndentationError: unexpected indent in tests/test_capsule_ground.py line 136)*
- `mypy` *(fails: option 'explicit_package_bases' already exists in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a28ad444a0832d80296e6fb54e7311