### PR TITLE
chore: clean mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,9 +2,3 @@
 ignore_missing_imports = True
 exclude = ^src/physics/
 explicit_package_bases = True
-
-
-
-explicit_package_bases = True
-        main
-        main


### PR DESCRIPTION
## Summary
- deduplicate mypy directives and drop stray lines

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: Unexpected indent in tests/test_capsule_ground.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a28ad63678832d870c4aa86568de94