### PR TITLE
Fix Capsule dataclass typing and cleanup stray markers

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,34 +1,10 @@
-
-
-
 const js = require('@eslint/js');
 const globals = require('globals');
 
-        main
-        main
 module.exports = [
   js.configs.recommended,
   {
-
-    ignores: ['**/*'],
-  },
-
     ignores: [
-
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ]
-
       '**/build/**',
       'node_modules/**',
       'build_ci_sanity/**',
@@ -52,9 +28,8 @@ module.exports = [
     },
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
+      semi: ['error', 'always']
     }
-        main
   }
-        main
 ];
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,8 +3,3 @@ ignore_missing_imports = True
 exclude = ^src/physics/
 explicit_package_bases = True
 
-
-
-explicit_package_bases = True
-        main
-        main

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,17 +1,15 @@
-
-import numpy as np
-
 """Minimal capsule representation for tests."""
 
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
-
     """Vertical capsule represented by a center point and radius.
 
     Parameters
@@ -24,26 +22,11 @@ class Capsule:
         Radius of the capsule.
     """
 
-    center: np.ndarray
-
-    """Simple vertical capsule defined by its center, half-height, and radius."""
-
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
         return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
@@ -55,4 +38,4 @@ class Capsule:
 
 
 __all__ = ["Capsule"]
-        main
+

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -133,5 +133,3 @@ pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
-        main
-        main

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -56,4 +56,3 @@ pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,
 )
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- consolidate Capsule dataclass into a single, properly typed definition
- clean stray `main` markers and fix linter/type-checker configs
- tidy tests to avoid spurious `main` tokens

## Testing
- `pytest`
- `npx eslint .`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68a28adfa390832da270fcf4e02f6c41