### PR TITLE
chore: tidy eslint ignores

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -5,7 +5,7 @@ module.exports = [
   js.configs.recommended,
   {
     ignores: [
-      '**/build/**',
+      'build/**',
       'node_modules/',
       'build_ci_sanity/',
       'cmake/',

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,20 +1,11 @@
-
-
-
 const js = require('@eslint/js');
 const globals = require('globals');
 
-        main
-        main
 module.exports = [
   js.configs.recommended,
   {
-
-    ignores: ['**/*'],
-  },
-
     ignores: [
-
+      '**/build/**',
       'node_modules/',
       'build_ci_sanity/',
       'cmake/',
@@ -27,24 +18,7 @@ module.exports = [
       'src/',
       'apps/',
       'scripts/'
-    ]
-
-      '**/build/**',
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'src/**',
-      'apps/**',
-      'scripts/**'
-    ]
-  },
-  {
+    ],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
@@ -54,7 +28,5 @@ module.exports = [
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
-        main
   }
-        main
 ];


### PR DESCRIPTION
## Summary
- remove stray 'main' lines from ESLint config
- merge duplicate ignore patterns into one array

## Testing
- `pytest` (fails: IndentationError: unexpected indent)
- `mypy .` (fails: Unexpected indent)
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a28aeedc8c832da0472278e36fc8f2