### PR TITLE
Clean up mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,9 +2,3 @@
 ignore_missing_imports = True
 exclude = ^src/physics/
 explicit_package_bases = True
-
-
-
-explicit_package_bases = True
-        main
-        main


### PR DESCRIPTION
## Summary
- remove duplicate `explicit_package_bases` and stray `main` entries from mypy configuration

## Testing
- `pytest` *(fails: IndentationError in tests/test_capsule_ground.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: Unexpected indent in tests/test_capsule_ground.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a28af0da24832dba8f2b068daec490