### PR TITLE
Remove stray main line from chunk store test

### DIFF
--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -56,4 +56,3 @@ pytest.skip(
     "chunk store roundtrip requires building C++ components; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- fix tests/test_chunk_store_cpp.py by removing stray `main` line so the module-level `pytest.skip` is the last statement

## Testing
- `pytest tests/test_chunk_store_cpp.py -q`
- `pytest -q` *(fails: IndentationError in unrelated tests)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy . --hide-error-context --strict` *(fails: unexpected indent in src/physics/aabb.py and duplicate config option)*

------
https://chatgpt.com/codex/tasks/task_e_68a28af2abe0832db343afddb319f154