### PR TITLE
Remove stray main from capsule player test

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- remove leftover `main` line so skip block is terminal statement in player controller capsule tests

## Testing
- `pytest tests/test_player_controller_capsule.py`
- `pytest`
- `npx eslint .`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a28af54044832d9ab75d5e290bee4c