### PR TITLE
Fix capsule voxel SAT helper functions

### DIFF
--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,49 +1,22 @@
-
-import numpy as np
-
 """Minimal capsule representation for tests."""
 
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule represented by a center point and radius.
-
-    Parameters
-    ----------
-    center:
-        Capsule midpoint ``(x, y, z)``.
-    half_height:
-        Distance from the center to the center of each spherical cap.
-    radius:
-        Radius of the capsule.
-    """
-
-    center: np.ndarray
-
-    """Simple vertical capsule defined by its center, half-height, and radius."""
+    """Vertical capsule defined by a center point, half-height, and radius."""
 
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
         return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
@@ -55,4 +28,4 @@ class Capsule:
 
 
 __all__ = ["Capsule"]
-        main
+

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,14 +1,8 @@
-
-"""Collision helpers for capsule vs voxel world using SAT."""
-
-from typing import Any, Optional, Tuple, cast
-
 """Collision helpers for a capsule against a voxel world using simple SAT tests."""
 
 from __future__ import annotations
 
 from typing import Optional, Protocol, Tuple, cast
-        main
 
 import numpy as np
 from numpy.typing import NDArray
@@ -17,34 +11,23 @@ from .capsule import Capsule
 from .voxel_solid import is_solid
 
 
-
-def closest_point_on_aabb(
-    p: np.ndarray, mn: np.ndarray, mx: np.ndarray
-) -> np.ndarray:
-    """Return the closest point on an axis-aligned box to ``p``."""
-
 class WorldProtocol(Protocol):
     """Minimal protocol required from the voxel world used in tests."""
 
-    def get_block_at_world_position(self, x: float, y: float, z: float) -> int: ...
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
+        ...
 
 
 def closest_point_on_aabb(
     p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> NDArray[np.float32]:
     """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
-        main
     return np.minimum(np.maximum(p, mn), mx)
 
 
 def closest_point_on_segment(
-
-    p: np.ndarray, a: np.ndarray, b: np.ndarray
-) -> np.ndarray:
-
     p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]
 ) -> NDArray[np.float32]:
-        main
     """Return the closest point on the segment ``ab`` to ``p``."""
     ab = b - a
     t = np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9)
@@ -52,15 +35,9 @@ def closest_point_on_segment(
 
 
 def capsule_box_penetration(
-
-    cap: Capsule, mn: np.ndarray, mx: np.ndarray
-) -> Tuple[bool, Optional[np.ndarray], float]:
-    """Compute penetration of ``cap`` against an axis-aligned box."""
-
     cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
     """Check penetration of ``cap`` against an axis-aligned box."""
-        main
     box_center = (mn + mx) * 0.5
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
@@ -68,49 +45,30 @@ def capsule_box_penetration(
     dist = np.linalg.norm(v)
     pen = cap.radius - dist
     if pen > 0.0:
-        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-
-        return True, cast(np.ndarray, normal), float(pen)
-    return False, None, 0.0
-
-
-def resolve_capsule_world(
-    cap: Capsule, world: Any, max_iters: int = 8
-) -> Tuple[np.ndarray, bool]:
-    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
-    total_offset = np.zeros(3, dtype=np.float32)
-
+        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array(
+            [0.0, 1.0, 0.0], dtype=np.float32
+        )
         return True, cast(NDArray[np.float32], normal), float(pen)
     return False, None, 0.0
 
 
 def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
     """Return integer min/max voxel coordinates overlapped by ``cap``."""
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
+    mn = cap.center - np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
+    mx = cap.center + np.array(
+        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+    )
     return np.floor(mn).astype(int), np.floor(mx).astype(int)
 
 
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[np.ndarray, bool]:
-    """Very small helper used in tests to keep the capsule above solid blocks."""
-    off = np.zeros(3, dtype=np.float32)
-        main
+def resolve_capsule_world(
+    cap: Capsule, world: WorldProtocol, max_iters: int = 8
+) -> Tuple[NDArray[np.float32], bool]:
+    """Resolve capsule against the voxel ``world`` and return offset and ground state."""
+    total_offset: NDArray[np.float32] = np.zeros(3, dtype=np.float32)
     ground = False
-    mn, mx = compute_capsule_voxel_bounds(cap)
-    for y in range(mn[1], mx[1] + 1):
-        for z in range(mn[2], mx[2] + 1):
-            for x in range(mn[0], mx[0] + 1):
-                if not is_solid(world.get_block_at_world_position(float(x), float(y), float(z))):
-                    continue
-                block_top = y + 1.0
-                bottom = cap.center[1] - (cap.half_height + cap.radius)
-                if bottom < block_top:
-                    delta = block_top - bottom
-                    cap.center[1] += delta
-                    off[1] += delta
-                    ground = True
-    return off, ground
-
 
     for _ in range(max_iters):
         mn = cap.center - np.array(
@@ -123,12 +81,12 @@ def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[np.ndarra
         bb_max = np.floor(mx).astype(int)
 
         max_pen = 0.0
-        hit_n: Optional[np.ndarray] = None
+        hit_n: Optional[NDArray[np.float32]] = None
         for y in range(bb_min[1] - 1, bb_max[1] + 2):
             for z in range(bb_min[2] - 1, bb_max[2] + 2):
                 for x in range(bb_min[0] - 1, bb_max[0] + 2):
                     bt = world.get_block_at_world_position(float(x), float(y), float(z))
-                    if not bt:
+                    if not is_solid(bt):
                         continue
                     mnv = np.array([x, y, z], dtype=np.float32)
                     mxv = mnv + 1.0
@@ -140,11 +98,10 @@ def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> Tuple[np.ndarra
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n is not None and hit_n[1] > 0.7:
+        if hit_n[1] > 0.7:
             ground = True
 
     return total_offset, ground
-
 
 
 __all__ = [
@@ -155,4 +112,4 @@ __all__ = [
     "compute_capsule_voxel_bounds",
     "resolve_capsule_world",
 ]
-        main
+

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -98,7 +98,7 @@ def resolve_capsule_world(
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n[1] > 0.7:
+        if hit_n is not None and hit_n[1] > 0.7:
             ground = True
 
     return total_offset, ground


### PR DESCRIPTION
## Summary
- refactor capsule helper dataclass and SAT utility functions
- remove duplicate definitions and add precise typing

## Testing
- `ruff check src/physics/capsule.py src/physics/capsule_voxel_sat.py`
- `mypy --follow-imports=skip src/physics/capsule_voxel_sat.py src/physics/capsule.py`
- `npx eslint .` *(fails: eslint.config.cjs: SyntaxError: Unexpected token ':')*
- `pytest` *(fails: IndentationError in tests/test_capsule_ground.py and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a28afc6398832db6b37964baa27870