### PR TITLE
Simplify capsule dataclass

### DIFF
--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,18 +1,13 @@
-
-import numpy as np
-
-"""Minimal capsule representation for tests."""
-
 from __future__ import annotations
 
-        main
 from dataclasses import dataclass
+import numpy as np
+from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule represented by a center point and radius.
+    """Simple vertical capsule defined by its center, half-height, and radius.
 
     Parameters
     ----------
@@ -24,26 +19,11 @@ class Capsule:
         Radius of the capsule.
     """
 
-    center: np.ndarray
-
-    """Simple vertical capsule defined by its center, half-height, and radius."""
-
     center: NDArray[np.float32]
-        main
     half_height: float
     radius: float
 
     @property
-
-    def seg_a(self) -> np.ndarray:
-        """Center of the top spherical cap."""
-        return self.center + np.array([0, self.half_height, 0], dtype=np.float32)
-
-    @property
-    def seg_b(self) -> np.ndarray:
-        """Center of the bottom spherical cap."""
-        return self.center - np.array([0, self.half_height, 0], dtype=np.float32)
-
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
         return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
@@ -55,4 +35,3 @@ class Capsule:
 
 
 __all__ = ["Capsule"]
-        main


### PR DESCRIPTION
## Summary
- refactor Capsule dataclass to define center/half_height/radius once and add segment properties

## Testing
- `npx eslint node_modules/isexe/index.js --no-config-lookup`
- `mypy . --config-file=/tmp/empty_mypy.ini`
- `pytest` *(fails: IndentationError in other tests)*
- `pytest tests/test_capsule_properties.py`


------
https://chatgpt.com/codex/tasks/task_e_68a28afdf6b4832dbf4ec66e97aaa18f