### PR TITLE
chore: simplify capsule ground test

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -33,7 +33,7 @@ def resolve_capsule_world(cap: CapsulePy, world) -> tuple[np.ndarray, bool]:
 class DummyWorld:
     """World with solid blocks below ``y == 0``."""
 
-    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:  # noqa: D401 - simple stub
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
         return 1 if y < 0.0 else 0
 
 

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 
 
-
 @dataclass
 class CapsulePy:
     """Simple vertical capsule used for Python collision checks."""
@@ -19,6 +18,7 @@ class CapsulePy:
 
 def resolve_capsule_world(cap: CapsulePy, world) -> tuple[np.ndarray, bool]:
     """Push the capsule upward if it intersects the ground."""
+
     off = np.zeros(3, dtype=np.float32)
     bottom = cap.center[1] - (cap.half_height + cap.radius)
     ground = False
@@ -27,25 +27,13 @@ def resolve_capsule_world(cap: CapsulePy, world) -> tuple[np.ndarray, bool]:
         cap.center[1] += delta
         off[1] = delta
         ground = True
-def resolve_capsule_world(cap: CapsulePy, world) -> tuple[CapsulePy, np.ndarray, bool]:
-    """Push the capsule upward if it intersects the ground. Returns a new CapsulePy instance."""
-    off = np.zeros(3, dtype=np.float32)
-    bottom = cap.center[1] - (cap.half_height + cap.radius)
-    ground = False
-    new_center = np.copy(cap.center)
-    if world.get_block_at_world_position(cap.center[0], bottom - 1e-4, cap.center[2]):
-        delta = -bottom
-        new_center[1] += delta
-        off[1] = delta
-        ground = True
-    new_cap = CapsulePy(new_center, cap.half_height, cap.radius)
-    return new_cap, off, ground
+    return off, ground
 
 
 class DummyWorld:
     """World with solid blocks below ``y == 0``."""
 
-    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
+    def get_block_at_world_position(self, x: float, y: float, z: float) -> int:  # noqa: D401 - simple stub
         return 1 if y < 0.0 else 0
 
 
@@ -90,11 +78,16 @@ lib.resolve_capsule_ground.restype = ctypes.c_int
 
 
 def test_capsule_ground_collision() -> None:
+    """Capsule should be pushed above the ground by both Python and C++ helpers."""
+
     world = DummyWorld()
+
+    # Python helper
     cap_py = CapsulePy(np.array([0.0, 0.2, 0.0], dtype=np.float32), 0.9, 0.3)
     off, ground = resolve_capsule_world(cap_py, world)
     assert ground and cap_py.center[1] >= 0.0, (off, cap_py.center, ground)
 
+    # C++ helper
     cap = Capsule(Vec3(0.0, 0.2, 0.0), 0.9, 0.3)
     off_c = Vec3()
     grounded = lib.resolve_capsule_ground(ctypes.byref(cap), ctypes.byref(off_c))
@@ -102,36 +95,3 @@ def test_capsule_ground_collision() -> None:
     assert abs(cap.center.y - 1.2) < 1e-4
     assert off_c.y == pytest.approx(1.0, abs=1e-4)
 
-spec = importlib.util.find_spec("src.physics.capsule_voxel_sat")
-if spec is None:  # pragma: no cover - skip if module cannot be imported
-    pytest.skip("capsule_voxel_sat module unavailable", allow_module_level=True)
-try:
-    capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
-except Exception:  # pragma: no cover - skip if module import fails
-    pytest.skip("capsule_voxel_sat module unavailable", allow_module_level=True)
-resolve_capsule_world = capsule_voxel_sat.resolve_capsule_world
-
-
-class DummyWorld:
-    def get_block_at_world_position(self, x, y, z):
-        return 1 if int(y) < 0 else 0  # ground at y=0
-
-
-def test_capsule_ground_collision():
-    world = DummyWorld()
-    cap = Capsule(
-        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
-        half_height=0.9,
-        radius=0.3,
-    )
-    off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
-
-import pytest
-
-pytest.skip(
-    "capsule ground collision tests require native extensions not built in CI",
-    allow_module_level=True,
-)
-        main
-        main


### PR DESCRIPTION
## Summary
- trim duplicate helpers and stray lines in capsule ground test
- clarify Python/C++ comparison for capsule-ground collisions

## Testing
- `pytest` *(fails: IndentationError in unrelated test)*
- `mypy` *(fails: option 'explicit_package_bases' already exists)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*


------
https://chatgpt.com/codex/tasks/task_e_68a28b1183b0832d8d28a61b9fec56b1