### PR TITLE
fix tests by removing stray main lines

### DIFF
--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -133,5 +133,3 @@ pytest.skip(
     "capsule ground collision tests require native extensions not built in CI",
     allow_module_level=True,
 )
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -92,4 +92,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-        main


### PR DESCRIPTION
## Summary
- remove extraneous `main` lines following module-level skips in capsule tests

## Testing
- `pytest tests/test_player_controller_capsule.py tests/test_capsule_ground.py -q`
- `pytest -q` *(fails: IndentationError in unrelated modules)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy` *(fails: mypy.ini has duplicate options)*

------
https://chatgpt.com/codex/tasks/task_e_68a290975cfc832dbade9a19af6eb404