### PR TITLE
Add voxel fill compute shader and dispatch

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,37 +1,11 @@
 const js = require('@eslint/js');
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
     ignores: [
       '**/build/**',
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -42,53 +16,16 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
+      'scripts/**'
     ],
-        main
-  },
-  {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
+      globals: { ...globals.node, ...globals.es2021 }
     },
     rules: {
       'no-unused-vars': 'warn',
-
       semi: ['error', 'always']
     }
   }
-
-
-      semi: ['error', 'always'],
-    },
-  },
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-];
-
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,30 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
-exclude = (^src/physics/|tests/test_capsule_ground.py)
 explicit_package_bases = True
-
-
+# Skip type checking for physics module and tests
 exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main

--- a/shaders_vk/voxel_fill.comp.glsl
+++ b/shaders_vk/voxel_fill.comp.glsl
@@ -1,0 +1,22 @@
+#version 450
+layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout (set = 0, binding = 0, r8ui) uniform readonly  uimage3D uSurface;
+layout (set = 0, binding = 1, r8ui) uniform writeonly uimage3D uSolid;
+
+void main() {
+    ivec2 xy = ivec2(gl_GlobalInvocationID.xy);
+    ivec3 size = imageSize(uSurface);
+    if (xy.x >= size.x || xy.y >= size.y) return;
+    bool inside = false;
+    for (int z = 0; z < size.z; ++z) {
+        ivec3 pos = ivec3(xy, z);
+        uint occ = imageLoad(uSurface, pos).r;
+        if (occ != 0u) {
+            inside = !inside;
+            imageStore(uSolid, pos, uvec4(1, 0, 0, 0));
+        } else {
+            imageStore(uSolid, pos, uvec4(inside ? 1u : 0u, 0, 0, 0));
+        }
+    }
+}

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -47,7 +47,9 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     VkShaderModuleCreateInfo smci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
     smci.codeSize = spirv.size() * 4; smci.pCode = spirv.data();
     VkShaderModule sm; vkCreateShaderModule(device, &smci, nullptr, &sm);
-
+    VkShaderModule sm;
+    VkResult sm_res = vkCreateShaderModule(device, &smci, nullptr, &sm);
+    if (sm_res != VK_SUCCESS) return false;
     VkComputePipelineCreateInfo cpci{ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     cpci.stage = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
     cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -39,7 +39,8 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
 
     VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
     plci.setLayoutCount = 1; plci.pSetLayouts = &m_dset_layout;
-    vkCreatePipelineLayout(device, &plci, nullptr, &m_pipe_layout);
+    VkResult pl_result = vkCreatePipelineLayout(device, &plci, nullptr, &m_pipe_layout);
+    if (pl_result != VK_SUCCESS) return false;
 
     auto spirv = load_spirv_file("spv/voxel_fill.comp.spv");
     if (spirv.empty()) return false;

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -1,0 +1,88 @@
+#include "voxel_fill.hpp"
+#include <vector>
+#include <cstdio>
+
+namespace voxelvk {
+
+static std::vector<uint32_t> load_spirv_file(const char* path) {
+    std::vector<uint32_t> data;
+    FILE* f = fopen(path, "rb");
+    if (!f) { std::fprintf(stderr, "[voxel_fill] Could not open %s\n", path); return data; }
+    fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
+    data.resize((size_t)sz / 4); fread(data.data(), 1, (size_t)sz, f); fclose(f);
+    return data;
+}
+
+bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
+    m_device = device;
+    VkDescriptorSetLayoutBinding b[2] = {};
+    for (int i = 0; i < 2; ++i) {
+        b[i].binding = i; b[i].descriptorCount = 1;
+        b[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        b[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
+    }
+    VkDescriptorSetLayoutCreateInfo dsl{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
+    dsl.bindingCount = 2; dsl.pBindings = b;
+    vkCreateDescriptorSetLayout(device, &dsl, nullptr, &m_dset_layout);
+
+    VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
+    plci.setLayoutCount = 1; plci.pSetLayouts = &m_dset_layout;
+    vkCreatePipelineLayout(device, &plci, nullptr, &m_pipe_layout);
+
+    auto spirv = load_spirv_file("spv/voxel_fill.comp.spv");
+    if (spirv.empty()) return false;
+    VkShaderModuleCreateInfo smci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
+    smci.codeSize = spirv.size() * 4; smci.pCode = spirv.data();
+    VkShaderModule sm; vkCreateShaderModule(device, &smci, nullptr, &sm);
+
+    VkComputePipelineCreateInfo cpci{ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
+    cpci.stage = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
+    cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
+    cpci.stage.module = sm; cpci.stage.pName = "main";
+    cpci.layout = m_pipe_layout;
+    vkCreateComputePipelines(device, cache, 1, &cpci, nullptr, &m_pipeline);
+    vkDestroyShaderModule(device, sm, nullptr);
+
+    VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps.descriptorCount = 2;
+    VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+    dpci.maxSets = 1; dpci.poolSizeCount = 1; dpci.pPoolSizes = &ps;
+    vkCreateDescriptorPool(device, &dpci, nullptr, &m_pool);
+    return true;
+}
+
+void VoxelFill::destroy(VkDevice device) {
+    if (m_pool) vkDestroyDescriptorPool(device, m_pool, nullptr);
+    if (m_pipeline) vkDestroyPipeline(device, m_pipeline, nullptr);
+    if (m_pipe_layout) vkDestroyPipelineLayout(device, m_pipe_layout, nullptr);
+    if (m_dset_layout) vkDestroyDescriptorSetLayout(device, m_dset_layout, nullptr);
+    m_pool = m_pipeline = m_pipe_layout = m_dset_layout = VK_NULL_HANDLE;
+    m_device = VK_NULL_HANDLE;
+}
+
+void VoxelFill::dispatch(VkCommandBuffer cmd,
+                         VkImageView surface_r8ui,
+                         VkImageView out_r8ui,
+                         uint32_t SX, uint32_t SY, uint32_t SZ) {
+    VkDescriptorSetAllocateInfo dsai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
+    dsai.descriptorPool = m_pool; dsai.descriptorSetCount = 1; dsai.pSetLayouts = &m_dset_layout;
+    VkDescriptorSet ds; vkAllocateDescriptorSets(m_device, &dsai, &ds);
+
+    auto storage_image = [](VkImageView v) {
+        VkDescriptorImageInfo ii{}; ii.imageView = v; ii.imageLayout = VK_IMAGE_LAYOUT_GENERAL; return ii; };
+    VkDescriptorImageInfo i0 = storage_image(surface_r8ui);
+    VkDescriptorImageInfo i1 = storage_image(out_r8ui);
+    VkWriteDescriptorSet w[2]{};
+    for (int i = 0; i < 2; ++i) {
+        w[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET; w[i].dstSet = ds;
+        w[i].dstBinding = i; w[i].descriptorCount = 1;
+        w[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    }
+    w[0].pImageInfo = &i0; w[1].pImageInfo = &i1; vkUpdateDescriptorSets(m_device, 2, w, 0, nullptr);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipe_layout, 0, 1, &ds, 0, nullptr);
+    uint32_t gx = (SX + 7) / 8, gy = (SY + 7) / 8;
+    vkCmdDispatch(cmd, gx, gy, 1);
+}
+
+} // namespace voxelvk

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -9,7 +9,18 @@ static std::vector<uint32_t> load_spirv_file(const char* path) {
     FILE* f = fopen(path, "rb");
     if (!f) { std::fprintf(stderr, "[voxel_fill] Could not open %s\n", path); return data; }
     fseek(f, 0, SEEK_END); long sz = ftell(f); fseek(f, 0, SEEK_SET);
-    data.resize((size_t)sz / 4); fread(data.data(), 1, (size_t)sz, f); fclose(f);
+    if (sz < 0 || sz % 4 != 0) {
+        std::fprintf(stderr, "[voxel_fill] File size of %s is not divisible by 4 or is negative (%ld bytes)\n", path, sz);
+        fclose(f);
+        return data;
+    }
+    data.resize((size_t)sz / 4);
+    size_t bytes_read = fread(data.data(), 1, (size_t)sz, f);
+    fclose(f);
+    if (bytes_read != (size_t)sz) {
+        std::fprintf(stderr, "[voxel_fill] Failed to read all bytes from %s (read %zu of %ld)\n", path, bytes_read, sz);
+        data.clear();
+    }
     return data;
 }
 

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -108,7 +108,7 @@ void VoxelFill::dispatch(VkCommandBuffer cmd,
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipeline);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipe_layout, 0, 1, &ds, 0, nullptr);
     uint32_t gx = (SX + 7) / 8, gy = (SY + 7) / 8;
-    vkCmdDispatch(cmd, gx, gy, 1);
+    vkCmdDispatch(cmd, gx, gy, SZ);
     vkFreeDescriptorSets(m_device, m_pool, 1, &ds);
 }
 

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -56,7 +56,11 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     cpci.stage.module = sm; cpci.stage.pName = "main";
     cpci.layout = m_pipe_layout;
     vkCreateComputePipelines(device, cache, 1, &cpci, nullptr, &m_pipeline);
+    VkResult pipelineResult = vkCreateComputePipelines(device, cache, 1, &cpci, nullptr, &m_pipeline);
     vkDestroyShaderModule(device, sm, nullptr);
+    if (pipelineResult != VK_SUCCESS) {
+        return false;
+    }
 
     VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps.descriptorCount = 2;
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -34,7 +34,8 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     }
     VkDescriptorSetLayoutCreateInfo dsl{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
     dsl.bindingCount = 2; dsl.pBindings = b;
-    vkCreateDescriptorSetLayout(device, &dsl, nullptr, &m_dset_layout);
+    VkResult res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &m_dset_layout);
+    if (res != VK_SUCCESS) return false;
 
     VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
     plci.setLayoutCount = 1; plci.pSetLayouts = &m_dset_layout;

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -45,6 +45,7 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
 
     VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps.descriptorCount = 2;
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
+    dpci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     dpci.maxSets = 1; dpci.poolSizeCount = 1; dpci.pPoolSizes = &ps;
     vkCreateDescriptorPool(device, &dpci, nullptr, &m_pool);
     return true;
@@ -62,7 +63,7 @@ void VoxelFill::destroy(VkDevice device) {
 void VoxelFill::dispatch(VkCommandBuffer cmd,
                          VkImageView surface_r8ui,
                          VkImageView out_r8ui,
-                         uint32_t SX, uint32_t SY, uint32_t SZ) {
+                         uint32_t SX, uint32_t SY) {
     VkDescriptorSetAllocateInfo dsai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
     dsai.descriptorPool = m_pool; dsai.descriptorSetCount = 1; dsai.pSetLayouts = &m_dset_layout;
     VkDescriptorSet ds; vkAllocateDescriptorSets(m_device, &dsai, &ds);
@@ -83,6 +84,7 @@ void VoxelFill::dispatch(VkCommandBuffer cmd,
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, m_pipe_layout, 0, 1, &ds, 0, nullptr);
     uint32_t gx = (SX + 7) / 8, gy = (SY + 7) / 8;
     vkCmdDispatch(cmd, gx, gy, 1);
+    vkFreeDescriptorSets(m_device, m_pool, 1, &ds);
 }
 
 } // namespace voxelvk

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -66,7 +66,8 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
     dpci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     dpci.maxSets = 1; dpci.poolSizeCount = 1; dpci.pPoolSizes = &ps;
-    vkCreateDescriptorPool(device, &dpci, nullptr, &m_pool);
+    VkResult poolResult = vkCreateDescriptorPool(device, &dpci, nullptr, &m_pool);
+    if (poolResult != VK_SUCCESS) return false;
     return true;
 }
 

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -86,7 +86,12 @@ void VoxelFill::dispatch(VkCommandBuffer cmd,
                          uint32_t SX, uint32_t SY) {
     VkDescriptorSetAllocateInfo dsai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
     dsai.descriptorPool = m_pool; dsai.descriptorSetCount = 1; dsai.pSetLayouts = &m_dset_layout;
-    VkDescriptorSet ds; vkAllocateDescriptorSets(m_device, &dsai, &ds);
+    VkDescriptorSet ds;
+    VkResult alloc_result = vkAllocateDescriptorSets(m_device, &dsai, &ds);
+    if (alloc_result != VK_SUCCESS) {
+        std::fprintf(stderr, "[voxel_fill] vkAllocateDescriptorSets failed with error code %d\n", alloc_result);
+        return;
+    }
 
     auto storage_image = [](VkImageView v) {
         VkDescriptorImageInfo ii{}; ii.imageView = v; ii.imageLayout = VK_IMAGE_LAYOUT_GENERAL; return ii; };

--- a/src/render/voxel_fill.hpp
+++ b/src/render/voxel_fill.hpp
@@ -11,7 +11,7 @@ struct VoxelFill {
     void dispatch(VkCommandBuffer cmd,
                   VkImageView surface_r8ui,
                   VkImageView out_r8ui,
-                  uint32_t SX, uint32_t SY, uint32_t SZ);
+                  uint32_t SX, uint32_t SY);
 
 private:
     VkDevice m_device = VK_NULL_HANDLE;

--- a/src/render/voxel_fill.hpp
+++ b/src/render/voxel_fill.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace voxelvk {
+
+struct VoxelFill {
+    bool init(VkDevice device, VkPipelineCache cache);
+    void destroy(VkDevice device);
+
+    void dispatch(VkCommandBuffer cmd,
+                  VkImageView surface_r8ui,
+                  VkImageView out_r8ui,
+                  uint32_t SX, uint32_t SY, uint32_t SZ);
+
+private:
+    VkDevice m_device = VK_NULL_HANDLE;
+    VkDescriptorSetLayout m_dset_layout = VK_NULL_HANDLE;
+    VkPipelineLayout m_pipe_layout = VK_NULL_HANDLE;
+    VkPipeline m_pipeline = VK_NULL_HANDLE;
+    VkDescriptorPool m_pool = VK_NULL_HANDLE;
+};
+
+} // namespace voxelvk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,4 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
->        main


### PR DESCRIPTION
## Summary
- Add compute shader to fill 3D voxel interiors using parity scanning
- Add Vulkan helper to dispatch voxel fill compute shader

## Testing
- `pytest` *(fails: SyntaxError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: duplicate option in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a38c6fef90832d9709b59724b03660