### PR TITLE
Add jump-flood SDF generator

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -42,6 +42,14 @@ if(TARGET VoxelVK_Elite_ALL)
   target_include_directories(VoxelVK_Elite_ALL PRIVATE ${CMAKE_SOURCE_DIR}/external/vma)
 endif()
 
+# --- SDF generator staging pipeline ---
+if(TARGET VoxelVK_Elite_ALL)
+  set(VOXELVK_ELITE_SOURCES)
+  list(APPEND VOXELVK_ELITE_SOURCES src/render/sdf_generator.cpp)
+  target_sources(VoxelVK_Elite_ALL PRIVATE ${VOXELVK_ELITE_SOURCES})
+  target_include_directories(VoxelVK_Elite_ALL PRIVATE ${CMAKE_SOURCE_DIR}/external/vma)
+endif()
+
 add_custom_target(mirror_spv_ibl ALL
   COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/assets/spv/ibl
   COMMAND ${CMAKE_COMMAND} -E copy

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,37 +1,10 @@
 const js = require('@eslint/js');
-
 const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
-    ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
     ignores: [
       '**/build/**',
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -42,53 +15,16 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
+      'scripts/**'
     ],
-        main
-  },
-  {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
+      globals: { ...globals.node, ...globals.es2021 }
     },
     rules: {
       'no-unused-vars': 'warn',
-
       semi: ['error', 'always']
     }
   }
-
-
-      semi: ['error', 'always'],
-    },
-  },
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-];
-
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,30 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
-exclude = (^src/physics/|tests/test_capsule_ground.py)
 explicit_package_bases = True
-
-
 exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main

--- a/shaders_vk/sdf_jump_flood.comp.glsl
+++ b/shaders_vk/sdf_jump_flood.comp.glsl
@@ -1,0 +1,28 @@
+#version 450
+#extension GL_EXT_samplerless_texture_functions : enable
+layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
+layout(set = 0, binding = 0, rgba16f) uniform readonly image3D uPrev;
+layout(set = 0, binding = 1, rgba16f) uniform writeonly image3D uNext;
+layout(push_constant) uniform PC {
+    int step;
+    int finalize;
+} pc;
+void main(){
+    ivec3 gid = ivec3(gl_GlobalInvocationID);
+    ivec3 dims = imageSize(uPrev);
+    if (any(greaterThanEqual(gid, dims))) return;
+    vec4 best = imageLoad(uPrev, gid);
+    float bestDist = best.w > 0.5 ? length(best.xyz - vec3(gid)) : 1e30;
+    for(int dz=-1; dz<=1; ++dz)
+    for(int dy=-1; dy<=1; ++dy)
+    for(int dx=-1; dx<=1; ++dx){
+        ivec3 o = gid + ivec3(dx,dy,dz)*pc.step;
+        if(any(lessThan(o, ivec3(0))) || any(greaterThanEqual(o, dims))) continue;
+        vec4 c = imageLoad(uPrev, o);
+        if(c.w <= 0.5) continue;
+        float d = length(c.xyz - vec3(gid));
+        if(d < bestDist){ best = c; bestDist = d; }
+    }
+    if(pc.finalize != 0) imageStore(uNext, gid, vec4(bestDist,0,0,0));
+    else imageStore(uNext, gid, best);
+}

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -90,7 +90,13 @@ bool GenerateSDF(VkDevice device,
     VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
     VkPipelineShaderStageCreateInfo ss{VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
     ss.stage=VK_SHADER_STAGE_COMPUTE_BIT; ss.module=cs; ss.pName="main";
-    cpci.stage=ss; cpci.layout=pl; VkPipeline pipe; if(vkCreateComputePipelines(device,VK_NULL_HANDLE,1,&cpci,nullptr,&pipe)!=VK_SUCCESS){vkDestroyShaderModule(device,cs,nullptr);return false;}
+    cpci.stage = ss;
+    cpci.layout = pl;
+    VkPipeline pipe;
+    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipe) != VK_SUCCESS) {
+        vkDestroyShaderModule(device, cs, nullptr);
+        return false;
+    }
     // Command buffer
     VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdPool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1; VkCommandBuffer cmd; vkAllocateCommandBuffers(device,&cbai,&cmd);
     VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; vkBeginCommandBuffer(cmd,&cbbi);

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -6,7 +6,9 @@ namespace voxelvk {
 static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path){
     FILE* f = fopen(path, "rb");
     if(!f) return VK_NULL_HANDLE;
-    fseek(f,0,SEEK_END); long len = ftell(f); fseek(f,0,SEEK_SET);
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
     std::vector<uint32_t> buf((size_t)len/4u);
     fread(buf.data(),1,buf.size()*4,f); fclose(f);
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -56,7 +56,11 @@ bool GenerateSDF(VkDevice device,
     binds[0].binding=0; binds[0].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; binds[0].descriptorCount=1; binds[0].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT;
     binds[1].binding=1; binds[1].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; binds[1].descriptorCount=1; binds[1].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT;
     VkDescriptorSetLayoutCreateInfo dslci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
-    dslci.bindingCount=2; dslci.pBindings=binds; VkDescriptorSetLayout dsl; if(vkCreateDescriptorSetLayout(device,&dslci,nullptr,&dsl)!=VK_SUCCESS) return false;
+    dslci.bindingCount = 2;
+    dslci.pBindings = binds;
+    VkDescriptorSetLayout dsl;
+    if (vkCreateDescriptorSetLayout(device, &dslci, nullptr, &dsl) != VK_SUCCESS)
+        return false;
     VkPushConstantRange pcr{VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(int)*2};
     VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
     plci.setLayoutCount=1; plci.pSetLayouts=&dsl; plci.pushConstantRangeCount=1; plci.pPushConstantRanges=&pcr;

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -28,7 +28,10 @@ bool GenerateSDF(VkDevice device,
                  VkFormat outFormat,
                  SDFVolume& out){
     (void)seedImage;
-    out.width = extent.width; out.height = extent.height; out.depth = extent.depth; out.format = outFormat;
+    out.width = extent.width;
+    out.height = extent.height;
+    out.depth = extent.depth;
+    out.format = outFormat;
     // Create output image
     VkImageCreateInfo img{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
     img.imageType = VK_IMAGE_TYPE_3D; img.format = outFormat; img.extent = extent;

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -68,7 +68,12 @@ bool GenerateSDF(VkDevice device,
     VkDescriptorPoolSize dps{VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,2};
     VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO}; dpci.maxSets=1; dpci.poolSizeCount=1; dpci.pPoolSizes=&dps;
     VkDescriptorPool pool; if(vkCreateDescriptorPool(device,&dpci,nullptr,&pool)!=VK_SUCCESS) return false;
-    VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO}; dsai.descriptorPool=pool; dsai.descriptorSetCount=1; dsai.pSetLayouts=&dsl; VkDescriptorSet ds; if(vkAllocateDescriptorSets(device,&dsai,&ds)!=VK_SUCCESS) return false;
+    VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+    dsai.descriptorPool = pool;
+    dsai.descriptorSetCount = 1;
+    dsai.pSetLayouts = &dsl;
+    VkDescriptorSet ds;
+    if (vkAllocateDescriptorSets(device, &dsai, &ds) != VK_SUCCESS) return false;
     auto UpdateDS=[&](VkImageView src, VkImageView dst){
         VkDescriptorImageInfo infos[2]{};
         infos[0].imageView=src; infos[0].imageLayout=VK_IMAGE_LAYOUT_GENERAL;

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -1,0 +1,126 @@
+#include "sdf_generator.hpp"
+#include <vector>
+#include <algorithm>
+#include <cstring>
+namespace voxelvk {
+static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path){
+    FILE* f = fopen(path, "rb");
+    if(!f) return VK_NULL_HANDLE;
+    fseek(f,0,SEEK_END); long len = ftell(f); fseek(f,0,SEEK_SET);
+    std::vector<uint32_t> buf((size_t)len/4u);
+    fread(buf.data(),1,buf.size()*4,f); fclose(f);
+    VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+    ci.codeSize = buf.size()*4; ci.pCode = buf.data();
+    VkShaderModule mod = VK_NULL_HANDLE;
+    if(vkCreateShaderModule(device,&ci,nullptr,&mod)!=VK_SUCCESS) return VK_NULL_HANDLE;
+    return mod;
+}
+bool GenerateSDF(VkDevice device,
+                 VkPhysicalDevice /*phys*/,
+                 VmaAllocator allocator,
+                 VkCommandPool cmdPool,
+                 VkQueue queue,
+                 VkImage seedImage,
+                 VkImageView seedView,
+                 VkExtent3D extent,
+                 VkFormat outFormat,
+                 SDFVolume& out){
+    (void)seedImage;
+    out.width = extent.width; out.height = extent.height; out.depth = extent.depth; out.format = outFormat;
+    // Create output image
+    VkImageCreateInfo img{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+    img.imageType = VK_IMAGE_TYPE_3D; img.format = outFormat; img.extent = extent;
+    img.mipLevels=1; img.arrayLayers=1; img.samples=VK_SAMPLE_COUNT_1_BIT; img.tiling=VK_IMAGE_TILING_OPTIMAL;
+    img.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+    VmaAllocationCreateInfo aci{}; aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE; aci.flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+    if(vmaCreateImage(allocator,&img,&aci,&out.image,&out.allocation,nullptr)!=VK_SUCCESS) return false;
+    VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+    ivci.image=out.image; ivci.viewType=VK_IMAGE_VIEW_TYPE_3D; ivci.format=out.format;
+    ivci.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; ivci.subresourceRange.levelCount=1; ivci.subresourceRange.layerCount=1;
+    if(vkCreateImageView(device,&ivci,nullptr,&out.view)!=VK_SUCCESS) return false;
+    // Temp ping/pong images (RGBA16F)
+    VkImageCreateInfo tmpImg = img; tmpImg.format = VK_FORMAT_R16G16B16A16_SFLOAT;
+    VkImage tmpA, tmpB; VmaAllocation tmpAAlloc, tmpBAlloc; VkImageView tmpAView, tmpBView;
+    if(vmaCreateImage(allocator,&tmpImg,&aci,&tmpA,&tmpAAlloc,nullptr)!=VK_SUCCESS) return false;
+    if(vmaCreateImage(allocator,&tmpImg,&aci,&tmpB,&tmpBAlloc,nullptr)!=VK_SUCCESS) return false;
+    ivci.image=tmpA; ivci.viewType=VK_IMAGE_VIEW_TYPE_3D; ivci.format=VK_FORMAT_R16G16B16A16_SFLOAT;
+    if(vkCreateImageView(device,&ivci,nullptr,&tmpAView)!=VK_SUCCESS) return false;
+    ivci.image=tmpB; if(vkCreateImageView(device,&ivci,nullptr,&tmpBView)!=VK_SUCCESS) return false;
+    // Descriptor set layout
+    VkDescriptorSetLayoutBinding binds[2]{};
+    binds[0].binding=0; binds[0].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; binds[0].descriptorCount=1; binds[0].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT;
+    binds[1].binding=1; binds[1].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; binds[1].descriptorCount=1; binds[1].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT;
+    VkDescriptorSetLayoutCreateInfo dslci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+    dslci.bindingCount=2; dslci.pBindings=binds; VkDescriptorSetLayout dsl; if(vkCreateDescriptorSetLayout(device,&dslci,nullptr,&dsl)!=VK_SUCCESS) return false;
+    VkPushConstantRange pcr{VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(int)*2};
+    VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+    plci.setLayoutCount=1; plci.pSetLayouts=&dsl; plci.pushConstantRangeCount=1; plci.pPushConstantRanges=&pcr;
+    VkPipelineLayout pl; if(vkCreatePipelineLayout(device,&plci,nullptr,&pl)!=VK_SUCCESS) return false;
+    VkDescriptorPoolSize dps{VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,2};
+    VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO}; dpci.maxSets=1; dpci.poolSizeCount=1; dpci.pPoolSizes=&dps;
+    VkDescriptorPool pool; if(vkCreateDescriptorPool(device,&dpci,nullptr,&pool)!=VK_SUCCESS) return false;
+    VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO}; dsai.descriptorPool=pool; dsai.descriptorSetCount=1; dsai.pSetLayouts=&dsl; VkDescriptorSet ds; if(vkAllocateDescriptorSets(device,&dsai,&ds)!=VK_SUCCESS) return false;
+    auto UpdateDS=[&](VkImageView src, VkImageView dst){
+        VkDescriptorImageInfo infos[2]{};
+        infos[0].imageView=src; infos[0].imageLayout=VK_IMAGE_LAYOUT_GENERAL;
+        infos[1].imageView=dst; infos[1].imageLayout=VK_IMAGE_LAYOUT_GENERAL;
+        VkWriteDescriptorSet writes[2]{ {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}, {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET} };
+        writes[0].dstSet=ds; writes[0].dstBinding=0; writes[0].descriptorCount=1; writes[0].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; writes[0].pImageInfo=&infos[0];
+        writes[1].dstSet=ds; writes[1].dstBinding=1; writes[1].descriptorCount=1; writes[1].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; writes[1].pImageInfo=&infos[1];
+        vkUpdateDescriptorSets(device,2,writes,0,nullptr);
+    };
+    // Shader module
+    VkShaderModule cs = LoadShaderModuleFromFile(device,"spv/sdf_jump_flood.comp.spv");
+    if(cs==VK_NULL_HANDLE) cs = LoadShaderModuleFromFile(device,"shaders/sdf_jump_flood.comp.glsl.spv");
+    if(cs==VK_NULL_HANDLE) return false;
+    VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+    VkPipelineShaderStageCreateInfo ss{VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
+    ss.stage=VK_SHADER_STAGE_COMPUTE_BIT; ss.module=cs; ss.pName="main";
+    cpci.stage=ss; cpci.layout=pl; VkPipeline pipe; if(vkCreateComputePipelines(device,VK_NULL_HANDLE,1,&cpci,nullptr,&pipe)!=VK_SUCCESS){vkDestroyShaderModule(device,cs,nullptr);return false;}
+    // Command buffer
+    VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdPool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1; VkCommandBuffer cmd; vkAllocateCommandBuffers(device,&cbai,&cmd);
+    VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; vkBeginCommandBuffer(cmd,&cbbi);
+    auto barrier=[&](VkImage img){
+        VkImageMemoryBarrier b{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        b.srcAccessMask=0; b.dstAccessMask=VK_ACCESS_SHADER_READ_BIT|VK_ACCESS_SHADER_WRITE_BIT;
+        b.oldLayout=VK_IMAGE_LAYOUT_UNDEFINED; b.newLayout=VK_IMAGE_LAYOUT_GENERAL;
+        b.image=img; b.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; b.subresourceRange.levelCount=1; b.subresourceRange.layerCount=1;
+        vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,0,0,nullptr,0,nullptr,1,&b);
+    };
+    barrier(out.image); barrier(tmpA); barrier(tmpB);
+    // Ping from seed
+    int maxDim = std::max({ (int)extent.width, (int)extent.height, (int)extent.depth });
+    int step = maxDim / 2; bool useTmpA=true; VkImageView srcView=seedView;
+    while(step>0){
+        VkImageView dstView=useTmpA?tmpAView:tmpBView;
+        UpdateDS(srcView,dstView);
+        vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pipe);
+        int pc[2]={step,0};
+        vkCmdPushConstants(cmd,pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(pc),pc);
+        vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pl,0,1,&ds,0,nullptr);
+        vkCmdDispatch(cmd,(extent.width+3)/4,(extent.height+3)/4,(extent.depth+3)/4);
+        VkImageMemoryBarrier bb{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        bb.srcAccessMask=VK_ACCESS_SHADER_WRITE_BIT; bb.dstAccessMask=VK_ACCESS_SHADER_READ_BIT;
+        bb.oldLayout=VK_IMAGE_LAYOUT_GENERAL; bb.newLayout=VK_IMAGE_LAYOUT_GENERAL; bb.image=dstView==tmpAView?tmpA:tmpB; bb.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; bb.subresourceRange.levelCount=1; bb.subresourceRange.layerCount=1;
+        vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,0,0,nullptr,0,nullptr,1,&bb);
+        srcView=dstView; useTmpA=!useTmpA; step/=2;
+    }
+    // Final pass to out
+    UpdateDS(srcView,out.view);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pipe);
+    int pcFin[2]={1,1};
+    vkCmdPushConstants(cmd,pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(pcFin),pcFin);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pl,0,1,&ds,0,nullptr);
+    vkCmdDispatch(cmd,(extent.width+3)/4,(extent.height+3)/4,(extent.depth+3)/4);
+    vkEndCommandBuffer(cmd);
+    VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd; vkQueueSubmit(queue,1,&si,VK_NULL_HANDLE); vkQueueWaitIdle(queue);
+    vkDestroyShaderModule(device,cs,nullptr); vkDestroyPipeline(device,pipe,nullptr); vkDestroyPipelineLayout(device,pl,nullptr); vkDestroyDescriptorSetLayout(device,dsl,nullptr); vkDestroyDescriptorPool(device,pool,nullptr);
+    vkDestroyImageView(device,tmpAView,nullptr); vkDestroyImageView(device,tmpBView,nullptr); vmaDestroyImage(allocator,tmpA,tmpAAlloc); vmaDestroyImage(allocator,tmpB,tmpBAlloc);
+    return true;
+}
+void DestroySDFVolume(VkDevice device, VmaAllocator allocator, SDFVolume& vol){
+    if(vol.view) vkDestroyImageView(device,vol.view,nullptr);
+    if(vol.image) vmaDestroyImage(allocator,vol.image,vol.allocation);
+    vol = {};
+}
+} // namespace voxelvk

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -14,7 +14,20 @@ static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     ci.codeSize = buf.size()*4; ci.pCode = buf.data();
     VkShaderModule mod = VK_NULL_HANDLE;
-    if(vkCreateShaderModule(device,&ci,nullptr,&mod)!=VK_SUCCESS) return VK_NULL_HANDLE;
+    if(!f) {
+        fprintf(stderr, "Error: Failed to open shader file '%s'\n", path);
+        return VK_NULL_HANDLE;
+    }
+    fseek(f,0,SEEK_END); long len = ftell(f); fseek(f,0,SEEK_SET);
+    std::vector<uint32_t> buf((size_t)len/4u);
+    fread(buf.data(),1,buf.size()*4,f); fclose(f);
+    VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+    ci.codeSize = buf.size()*4; ci.pCode = buf.data();
+    VkShaderModule mod = VK_NULL_HANDLE;
+    if(vkCreateShaderModule(device,&ci,nullptr,&mod)!=VK_SUCCESS) {
+        fprintf(stderr, "Error: Failed to create shader module from file '%s'\n", path);
+        return VK_NULL_HANDLE;
+    }
     return mod;
 }
 bool GenerateSDF(VkDevice device,

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -134,7 +134,11 @@ bool GenerateSDF(VkDevice device,
     vkCmdDispatch(cmd,(extent.width+3)/4,(extent.height+3)/4,(extent.depth+3)/4);
     vkEndCommandBuffer(cmd);
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd; vkQueueSubmit(queue,1,&si,VK_NULL_HANDLE); vkQueueWaitIdle(queue);
-    vkDestroyShaderModule(device,cs,nullptr); vkDestroyPipeline(device,pipe,nullptr); vkDestroyPipelineLayout(device,pl,nullptr); vkDestroyDescriptorSetLayout(device,dsl,nullptr); vkDestroyDescriptorPool(device,pool,nullptr);
+    vkDestroyShaderModule(device,cs,nullptr);
+    vkDestroyPipeline(device,pipe,nullptr);
+    vkDestroyPipelineLayout(device,pl,nullptr);
+    vkDestroyDescriptorSetLayout(device,dsl,nullptr);
+    vkDestroyDescriptorPool(device,pool,nullptr);
     vkDestroyImageView(device,tmpAView,nullptr); vkDestroyImageView(device,tmpBView,nullptr); vmaDestroyImage(allocator,tmpA,tmpAAlloc); vmaDestroyImage(allocator,tmpB,tmpBAlloc);
     return true;
 }

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -143,7 +143,10 @@ bool GenerateSDF(VkDevice device,
     vkDestroyPipelineLayout(device,pl,nullptr);
     vkDestroyDescriptorSetLayout(device,dsl,nullptr);
     vkDestroyDescriptorPool(device,pool,nullptr);
-    vkDestroyImageView(device,tmpAView,nullptr); vkDestroyImageView(device,tmpBView,nullptr); vmaDestroyImage(allocator,tmpA,tmpAAlloc); vmaDestroyImage(allocator,tmpB,tmpBAlloc);
+    vkDestroyImageView(device, tmpAView, nullptr);
+    vkDestroyImageView(device, tmpBView, nullptr);
+    vmaDestroyImage(allocator, tmpA, tmpAAlloc);
+    vmaDestroyImage(allocator, tmpB, tmpBAlloc);
     return true;
 }
 void DestroySDFVolume(VkDevice device, VmaAllocator allocator, SDFVolume& vol){

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -133,7 +133,11 @@ bool GenerateSDF(VkDevice device,
     vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pl,0,1,&ds,0,nullptr);
     vkCmdDispatch(cmd,(extent.width+3)/4,(extent.height+3)/4,(extent.depth+3)/4);
     vkEndCommandBuffer(cmd);
-    VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd; vkQueueSubmit(queue,1,&si,VK_NULL_HANDLE); vkQueueWaitIdle(queue);
+    VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
+    si.commandBufferCount = 1;
+    si.pCommandBuffers = &cmd;
+    vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE);
+    vkQueueWaitIdle(queue);
     vkDestroyShaderModule(device,cs,nullptr);
     vkDestroyPipeline(device,pipe,nullptr);
     vkDestroyPipelineLayout(device,pl,nullptr);

--- a/src/render/sdf_generator.hpp
+++ b/src/render/sdf_generator.hpp
@@ -1,0 +1,24 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+#include <cstdint>
+namespace voxelvk {
+struct SDFVolume {
+    VkImage       image = VK_NULL_HANDLE;
+    VkImageView   view  = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    uint32_t      width = 0, height = 0, depth = 0;
+    VkFormat      format = VK_FORMAT_R16_SFLOAT;
+};
+bool GenerateSDF(VkDevice device,
+                 VkPhysicalDevice phys,
+                 VmaAllocator allocator,
+                 VkCommandPool cmdPool,
+                 VkQueue queue,
+                 VkImage seedImage,
+                 VkImageView seedView,
+                 VkExtent3D extent,
+                 VkFormat outFormat,
+                 SDFVolume& out);
+void DestroySDFVolume(VkDevice device, VmaAllocator allocator, SDFVolume& vol);
+} // namespace voxelvk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,4 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
->        main


### PR DESCRIPTION
## Summary
- implement 3D jump-flood compute shader for SDF propagation
- add staging SDF generator pipeline using the shader and integrate into build
- clean up lint/type configs and flaky test module

## Testing
- `npx eslint .`
- `mypy --config-file mypy.ini .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38c7122e8832dae2537bf4049eebf