### PR TITLE
Add SAT-based voxelization shader

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,37 +1,15 @@
 const js = require('@eslint/js');
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
   {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+      globals: { ...globals.node, ...globals.es2021 }
+    },
     ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-    ignores: [
-      '**/build/**',
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -43,52 +21,11 @@ module.exports = [
       'tests/**',
       'apps/**',
       'scripts/**',
-
-      '**/build/**'
-    ]
-
+      'build/**'
     ],
-        main
-  },
-  {
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
     rules: {
       'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
       'semi': ['error', 'always']
     }
   }
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
 ];
-
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,30 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-
-exclude = (^src/physics/|tests/test_capsule_ground.py)
 explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main
+exclude = (?x)
+    ^src/physics/
+    |tests/test_capsule_ground.py

--- a/shaders_vk/voxelize_sat.comp.glsl
+++ b/shaders_vk/voxelize_sat.comp.glsl
@@ -1,7 +1,7 @@
 #version 450
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
-layout(set = 0, binding = 0, r8ui) uniform uimage3D uOccupancy;
+layout(set = 0, binding = 0, r32ui) uniform uimage3D uOccupancy;
 
 layout(push_constant) uniform PC {
     vec3 v0;
@@ -85,6 +85,6 @@ void main() {
     vec3 center = boxMin + vec3(pc.voxelSize * 0.5);
     vec3 half = vec3(pc.voxelSize * 0.5);
     if(triBoxOverlap(center, half, pc.v0, pc.v1, pc.v2)) {
-        imageStore(uOccupancy, coord, uvec4(1, 0, 0, 0));
+        imageAtomicOr(uOccupancy, coord, 1u);
     }
 }

--- a/shaders_vk/voxelize_sat.comp.glsl
+++ b/shaders_vk/voxelize_sat.comp.glsl
@@ -1,0 +1,90 @@
+#version 450
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0, r8ui) uniform uimage3D uOccupancy;
+
+layout(push_constant) uniform PC {
+    vec3 v0;
+    vec3 v1;
+    vec3 v2;
+    vec3 origin;
+    float voxelSize;
+    ivec3 minVoxel;
+    ivec3 gridDim;
+} pc;
+
+bool planeBoxOverlap(vec3 normal, float d, vec3 half) {
+    vec3 vmin, vmax;
+    for(int q = 0; q < 3; ++q) {
+        if(normal[q] > 0.0) {
+            vmin[q] = -half[q];
+            vmax[q] =  half[q];
+        } else {
+            vmin[q] =  half[q];
+            vmax[q] = -half[q];
+        }
+    }
+    if(dot(normal, vmin) + d > 0.0) return false;
+    if(dot(normal, vmax) + d >= 0.0) return true;
+    return false;
+}
+
+bool triBoxOverlap(vec3 center, vec3 half, vec3 v0, vec3 v1, vec3 v2) {
+    vec3 tv0 = v0 - center;
+    vec3 tv1 = v1 - center;
+    vec3 tv2 = v2 - center;
+    vec3 e0 = tv1 - tv0;
+    vec3 e1 = tv2 - tv1;
+    vec3 e2 = tv0 - tv2;
+
+    vec3 axes[9] = vec3[9](
+        vec3(0, -e0.z, e0.y),
+        vec3(e0.z, 0, -e0.x),
+        vec3(-e0.y, e0.x, 0),
+        vec3(0, -e1.z, e1.y),
+        vec3(e1.z, 0, -e1.x),
+        vec3(-e1.y, e1.x, 0),
+        vec3(0, -e2.z, e2.y),
+        vec3(e2.z, 0, -e2.x),
+        vec3(-e2.y, e2.x, 0)
+    );
+
+    for(int i = 0; i < 9; ++i) {
+        vec3 axis = axes[i];
+        if(length(axis) < 1e-6) continue;
+        float r = half.x * abs(axis.x) + half.y * abs(axis.y) + half.z * abs(axis.z);
+        float p0 = dot(tv0, axis);
+        float p1 = dot(tv1, axis);
+        float p2 = dot(tv2, axis);
+        float mn = min(p0, min(p1, p2));
+        float mx = max(p0, max(p1, p2));
+        if(mn > r || mx < -r) return false;
+    }
+
+    float minv, maxv;
+    minv = min(tv0.x, min(tv1.x, tv2.x));
+    maxv = max(tv0.x, max(tv1.x, tv2.x));
+    if(minv > half.x || maxv < -half.x) return false;
+    minv = min(tv0.y, min(tv1.y, tv2.y));
+    maxv = max(tv0.y, max(tv1.y, tv2.y));
+    if(minv > half.y || maxv < -half.y) return false;
+    minv = min(tv0.z, min(tv1.z, tv2.z));
+    maxv = max(tv0.z, max(tv1.z, tv2.z));
+    if(minv > half.z || maxv < -half.z) return false;
+
+    vec3 normal = cross(e0, e1);
+    float d = -dot(normal, tv0);
+    if(!planeBoxOverlap(normal, d, half)) return false;
+    return true;
+}
+
+void main() {
+    ivec3 coord = ivec3(gl_GlobalInvocationID) + pc.minVoxel;
+    if(any(greaterThanEqual(coord, pc.gridDim))) return;
+    vec3 boxMin = pc.origin + vec3(coord) * pc.voxelSize;
+    vec3 center = boxMin + vec3(pc.voxelSize * 0.5);
+    vec3 half = vec3(pc.voxelSize * 0.5);
+    if(triBoxOverlap(center, half, pc.v0, pc.v1, pc.v2)) {
+        imageStore(uOccupancy, coord, uvec4(1, 0, 0, 0));
+    }
+}

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,64 +1,15 @@
-
-
-
-        main
-        main
-        main
 """Minimal capsule representation for tests."""
 
-
-import numpy as np
-from dataclasses import dataclass
-
-from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-
-
-from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-
-        main
 from __future__ import annotations
 
 from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
-import numpy as np
-        main
-from numpy.typing import NDArray
-        main
-        main
-
 
 @dataclass
 class Capsule:
-
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-  
-  
-    """Vertical capsule represented by a center point and radius.
-
-    Parameters
-    ----------
-    center:
-        Capsule midpoint ``(x, y, z)``.
-    half_height:
-        Distance from the center to the center of each spherical cap.
-    radius:
-        Radius of the capsule.
-    """
-
-        main
-    """Simple vertical capsule defined by its center, half-height, and radius."""
-        main
-        main
-        main
+    """Vertical capsule defined by center, half-height, and radius."""
 
     center: NDArray[np.float32]
     half_height: float
@@ -76,13 +27,3 @@ class Capsule:
 
 
 __all__ = ["Capsule"]
-
-
-
-
-
-
-        main
-        main
-        main
-        main

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,17 +1,8 @@
-
 """Collision helpers for a capsule against a voxel world."""
 
-
-"""Capsule to voxel collision helpers used in tests."""
-
 from __future__ import annotations
 
-from typing import Any, Optional, Protocol, Tuple, cast
-        main
-
-from __future__ import annotations
-
-from typing import Protocol, Tuple
+from typing import Optional, Protocol, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -27,127 +18,63 @@ class WorldProtocol(Protocol):
         ...
 
 
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
-
 def closest_point_on_aabb(
     p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> NDArray[np.float32]:
-    """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
-    
-
-    return cast(NDArray[np.float32], np.minimum(np.maximum(p, mn), mx))
-
-
-
+    """Clamp point ``p`` to the box defined by ``mn`` and ``mx``."""
     return np.minimum(np.maximum(p, mn), mx)
 
 
-        main
 def closest_point_on_segment(
     p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]
 ) -> NDArray[np.float32]:
     """Return the closest point on the segment ``ab`` to ``p``."""
-
     ab = b - a
     t = float(np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9))
-    return cast(NDArray[np.float32], a + np.clip(t, 0.0, 1.0) * ab)
+    return a + np.clip(t, 0.0, 1.0) * ab
 
 
 def capsule_box_penetration(
     cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]
 ) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
     """Check penetration of ``cap`` against an axis-aligned box."""
-
-
-
-        main
-    box_center = (mn + mx) * 0.5
-    q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
+    center = (mn + mx) * 0.5
+    q_seg = closest_point_on_segment(center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
     v = q_seg - q_box
     dist = float(np.linalg.norm(v))
     pen = cap.radius - dist
     if pen > 0.0:
-
-        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-
         normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0.0, 1.0, 0.0], dtype=np.float32)
-        main
-        return True, cast(NDArray[np.float32], normal), float(pen)
+        return True, normal, pen
     return False, None, 0.0
 
 
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[NDArray[np.int_], NDArray[np.int_]]:
-    """Return integer min/max voxel coordinates overlapped by ``cap``."""
-
 def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[NDArray[np.int32], NDArray[np.int32]]:
-        main
     """Return integer min/max voxel coordinates overlapped by ``cap``."""
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    return np.floor(mn).astype(np.int32), np.floor(mx).astype(np.int32)
-        main
-
     mn = cap.center - np.array(
         [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
     )
     mx = cap.center + np.array(
         [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
     )
-    return np.floor(mn).astype(int), np.floor(mx).astype(int)
+    return np.floor(mn).astype(np.int32), np.floor(mx).astype(np.int32)
 
-
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> tuple[np.ndarray, bool]:
-    """Very small helper used in tests to keep the capsule above solid blocks."""
-    off = np.zeros(3, dtype=np.float32)
-    ground = False
-    mn, mx = compute_capsule_voxel_bounds(cap)
-    for y in range(mn[1], mx[1] + 1):
-        for z in range(mn[2], mx[2] + 1):
-            for x in range(mn[0], mx[0] + 1):
-                if not is_solid(world.get_block_at_world_position(float(x), float(y), float(z))):
-                    continue
-                block_top = y + 1.0
-                bottom = cap.center[1] - (cap.half_height + cap.radius)
-                if bottom < block_top:
-                    delta = block_top - bottom
-                    cap.center[1] += delta
-                    off[1] += delta
-                    ground = True
-    return off, ground
-
-        main
 
 def resolve_capsule_world(
     cap: Capsule, world: WorldProtocol, max_iters: int = 8
 ) -> Tuple[NDArray[np.float32], bool]:
     """Resolve ``cap`` against the voxel ``world`` and return total offset and ground state."""
-
-
-__all__ = ["WorldProtocol", "compute_capsule_voxel_bounds", "resolve_capsule_world"]
-
-def resolve_capsule_world(
-    cap: Capsule, world: WorldProtocol, max_iters: int = 8
-) -> Tuple[NDArray[np.float32], bool]:
-    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
-    total_offset = np.zeros(3, dtype=np.float32)
-    ground = False
-        main
-
     total_offset = np.zeros(3, dtype=np.float32)
     ground = False
     for _ in range(max_iters):
         bb_min, bb_max = compute_capsule_voxel_bounds(cap)
-
-        max_pen = 0.0
         hit_n: Optional[NDArray[np.float32]] = None
+        max_pen = 0.0
         for y in range(bb_min[1] - 1, bb_max[1] + 2):
             for z in range(bb_min[2] - 1, bb_max[2] + 2):
                 for x in range(bb_min[0] - 1, bb_max[0] + 2):
-                    bt = world.get_block_at_world_position(float(x), float(y), float(z))
-                    if not is_solid(bt):
+                    if not is_solid(world.get_block_at_world_position(float(x), float(y), float(z))):
                         continue
                     mnv = np.array([x, y, z], dtype=np.float32)
                     mxv = mnv + 1.0
@@ -159,9 +86,8 @@ def resolve_capsule_world(
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n is not None and hit_n[1] > 0.7:
+        if hit_n[1] > 0.7:
             ground = True
-
     return total_offset, ground
 
 
@@ -173,8 +99,3 @@ __all__ = [
     "compute_capsule_voxel_bounds",
     "resolve_capsule_world",
 ]
-
-
-
-        main
-        main

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -86,7 +86,7 @@ def resolve_capsule_world(
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n[1] > 0.7:
+        if hit_n is not None and hit_n[1] > 0.7:
             ground = True
     return total_offset, ground
 

--- a/src/physics/player_controller_capsule.py
+++ b/src/physics/player_controller_capsule.py
@@ -1,18 +1,4 @@
-
 """Capsule-based player controller used in tests."""
-
-
-"""Simple capsule-based player controller used in tests.
-
-This module provides a lightweight capsule character controller that uses
-Separating Axis Theorem (SAT) collision resolution against a voxel world.
-It is intentionally minimal and pure Python so that it can be exercised by
-unit tests without requiring the native physics engine.
-"""
-
-"""Capsule-based player controller used for tests."""
-        main
-        main
 
 from __future__ import annotations
 
@@ -21,31 +7,19 @@ from typing import Any, Dict
 import numpy as np
 from numpy.typing import NDArray
 
-from . import SPRINT_SPEED_MULTIPLIER
 from .capsule import Capsule
 from .capsule_voxel_sat import resolve_capsule_world
 
-
-# Multiplier applied to ``max_speed`` when sprint input is active.
 SPRINT_SPEED_MULTIPLIER = 1.6
 
 
-
-class PlayerControllerCapsule:
-    """Very small kinematic character controller represented by a capsule."""
-
 def get_horizontal_speed(controller: "PlayerControllerCapsule") -> float:
     """Return the horizontal speed of the controller."""
-
     return float(np.linalg.norm(controller.vel[[0, 2]]))
 
 
-        main
-
 class PlayerControllerCapsule:
-    """Basic kinematic character controller represented by a capsule."""
-
-        main
+    """Minimal kinematic capsule controller for tests."""
 
     def __init__(
         self,
@@ -56,25 +30,16 @@ class PlayerControllerCapsule:
         max_speed: float = 11.0,
         jump_speed: float = 9.5,
     ) -> None:
-
-
-    _first_speed_call = True
-
-    def __init__(self, world_manager: Any, spawn: NDArray[np.float32]) -> None:
-        main
-        main
         self.world = world_manager
         self.pos = spawn.astype(np.float32)
         self.vel = np.zeros(3, dtype=np.float32)
         self.radius = 0.3
         self.half_h = 0.9
-
-        self.step_height = 0.5
-        self.g = 28.0
-        self.max_speed = 11.0
-        self.jump_speed = 9.5
+        self.step_height = step_height
+        self.g = gravity
+        self.max_speed = max_speed
+        self.jump_speed = jump_speed
         self.on_ground = False
-
         self.input: Dict[str, int] = {
             "f": 0,
             "b": 0,
@@ -84,135 +49,50 @@ class PlayerControllerCapsule:
             "sprint": 0,
         }
 
-
-    # ------------------------------------------------------------------ helpers
-
-    # ------------------------------------------------------------------
-    # Helpers
-        main
     def set_input(self, mapping: Dict[str, int]) -> None:
-        """Update input state with values from ``mapping``."""
-
-
+        """Update input state."""
         self.input.update({k: v for k, v in mapping.items() if k in self.input})
 
     def _capsule(self) -> Capsule:
-
-        return Capsule(self.pos.copy(), self.half_h, self.radius)
-
-    # ---------------------------------------------------------------- movement
-    def update(self, dt: float, forward: NDArray[np.float32], right: NDArray[np.float32]) -> None:
-        """Advance the controller by ``dt`` seconds."""
-
-        """Return a capsule representing the player's current bounds."""
-
-        return Capsule(self.pos.copy(), self.half_h, self.radius)
-
-    def get_horizontal_speed(self) -> float:
-        """Return the magnitude of the horizontal velocity for this instance."""
-
-        return float(np.linalg.norm(self.vel[[0, 2]]))
-
-    # ------------------------------------------------------------------
-    # Simulation
-    def update(self, dt: float, forward: np.ndarray, right: np.ndarray) -> None:
-        """Advance the controller by ``dt`` seconds."""
-
-
-        self.input.update(mapping)
-
-    def _capsule(self) -> Capsule:
-        """Return a capsule representing the player's current bounds."""
-
         return Capsule(self.pos.copy(), self.half_h, self.radius)
 
     def update(self, dt: float, forward: NDArray[np.float32], right: NDArray[np.float32]) -> None:
         """Advance the controller by ``dt`` seconds."""
-
-        main
-        main 
-      wish = forward * (self.input["f"] - self.input["b"]) + right * (
+        wish = forward * (self.input["f"] - self.input["b"]) + right * (
             self.input["r"] - self.input["l"]
         )
         wish[1] = 0.0
         n = float(np.linalg.norm(wish))
         if n > 1e-6:
             wish /= n
-
-        target = self.max_speed * (SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0)
-
         target = self.max_speed * (
             SPRINT_SPEED_MULTIPLIER if self.input["sprint"] else 1.0
         )
-        main
         hv = self.vel.copy()
         hv[1] = 0.0
         accel = 50.0 if self.on_ground else 10.0
         self.vel += (wish * target - hv) * min(1.0, accel * dt)
-
-
-        # gravity and jumping
-        main
         self.vel[1] -= self.g * dt
         if self.on_ground and self.input["jump"]:
             self.vel[1] = self.jump_speed
             self.on_ground = False
-
         self.pos += self.vel * dt
-
         cap = self._capsule()
         off, ground = resolve_capsule_world(cap, self.world)
-        moved = not np.allclose(off, 0.0, atol=1e-6)
-        if not moved and (
-            self.input["f"] or self.input["b"] or self.input["l"] or self.input["r"]
-        ):
-            cap.center[1] += self.step_height
-            off, ground = resolve_capsule_world(cap, self.world)
-
-        self.pos = cap.center
-        self.on_ground = ground
-        if self.on_ground and self.vel[1] < 0.0:
-            self.vel[1] = 0.0
-
-
-        # final resolve in case of tiny overlaps
-        off2, ground2 = resolve_capsule_world(self._capsule(), self.world)
-        self.pos += off2
-        self.on_ground = self.on_ground or ground2
+        if np.any(off):
+            self.pos = cap.center + off
+        else:
+            self.pos = cap.center
+        self.on_ground = ground or self.on_ground
         if self.on_ground and self.vel[1] < 0.0:
             self.vel[1] = 0.0
 
     def get_horizontal_speed(self) -> float:
-        """Return the magnitude of the horizontal velocity for this instance."""
         return float(np.linalg.norm(self.vel[[0, 2]]))
 
-    def get_horizontal_speed(self) -> float:
-        """Return the magnitude of the horizontal velocity for this instance."""
 
-        speed = float(np.linalg.norm(self.vel[[0, 2]]))
-        if PlayerControllerCapsule._first_speed_call:
-            PlayerControllerCapsule._first_speed_call = False
-            return min(speed, self.max_speed + 1e-3)
-        return speed
-        main
-
-
-# ---------------------------------------------------------------------- helpers
-
-def get_horizontal_speed(controller: PlayerControllerCapsule) -> float:
-
-    """Return the horizontal speed of ``controller``."""
-    return controller.get_horizontal_speed()
-
-
-__all__ = ["PlayerControllerCapsule", "SPRINT_SPEED_MULTIPLIER", "get_horizontal_speed"]
-
-    """Return the magnitude of the horizontal velocity of ``controller``."""
-
-    return controller.get_horizontal_speed()
-
-
-        main
-__all__ = ["PlayerControllerCapsule", "get_horizontal_speed"]
-
-        main
+__all__ = [
+    "PlayerControllerCapsule",
+    "SPRINT_SPEED_MULTIPLIER",
+    "get_horizontal_speed",
+]

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,45 +1,22 @@
-
 """Utilities to query whether a voxel block type is solid."""
 
 from __future__ import annotations
 
-
-"""Utilities to query whether a voxel block type is solid."""
-
-from __future__ import annotations
-         main
-
-from __future__ import annotations
-
-from typing import Dict
-        main
-
 from typing import Dict
 
 
-        main
 class BlockType:
     """Enumeration of built-in block types used in tests."""
 
     AIR = 0
 
 
-
-# Registry describing block properties. Games can populate this as needed.
-
-
-# Adapt this to your engine's block registry
-BLOCK_PROPERTIES: Dict[int, Dict[str, bool]] = {}
-
 # Simple registry mapping block type IDs to property dictionaries.
-        main
-BLOCK_PROPERTIES: Dict[int, dict] = {}
-        main
+BLOCK_PROPERTIES: Dict[int, Dict[str, bool]] = {}
 
 
 def is_solid(block_type: int) -> bool:
     """Return ``True`` if ``block_type`` represents a solid block."""
-
     props = BLOCK_PROPERTIES.get(block_type)
     if props is None:
         return block_type != BlockType.AIR
@@ -47,9 +24,3 @@ def is_solid(block_type: int) -> bool:
 
 
 __all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]
-
-
-
-
-        main
-        main

--- a/src/render/voxelize_sat.cpp
+++ b/src/render/voxelize_sat.cpp
@@ -33,8 +33,13 @@ void VoxelizeMeshSAT(VkCommandBuffer cmd,
         glm::vec3 triMin = glm::min(t.v0, glm::min(t.v1, t.v2));
         glm::vec3 triMax = glm::max(t.v0, glm::max(t.v1, t.v2));
         glm::ivec3 minV = glm::floor((triMin - origin) / voxelSize);
-        glm::ivec3 maxV = glm::floor((triMax - origin) / voxelSize);
+        glm::ivec3 maxV = glm::ceil((triMax - origin) / voxelSize) - glm::ivec3(1);
+        minV = glm::clamp(minV, glm::ivec3(0), gridDim - glm::ivec3(1));
+        maxV = glm::clamp(maxV, glm::ivec3(0), gridDim - glm::ivec3(1));
         glm::ivec3 extent = maxV - minV + glm::ivec3(1);
+        if (extent.x <= 0 || extent.y <= 0 || extent.z <= 0) {
+            continue;
+        }
 
         VoxelizePush pc;
         pc.v0 = t.v0;

--- a/src/render/voxelize_sat.cpp
+++ b/src/render/voxelize_sat.cpp
@@ -1,0 +1,57 @@
+#include <vulkan/vulkan.h>
+#include <glm/glm.hpp>
+#include <vector>
+#include <algorithm>
+
+namespace voxelvk {
+
+struct Triangle {
+    glm::vec3 v0;
+    glm::vec3 v1;
+    glm::vec3 v2;
+};
+
+struct VoxelizePush {
+    glm::vec3 v0;
+    glm::vec3 v1;
+    glm::vec3 v2;
+    glm::vec3 origin;
+    float voxelSize;
+    glm::ivec3 minVoxel;
+    glm::ivec3 gridDim;
+};
+
+void VoxelizeMeshSAT(VkCommandBuffer cmd,
+                     VkPipeline pipeline,
+                     VkPipelineLayout layout,
+                     VkDescriptorSet occupancySet,
+                     const std::vector<Triangle>& tris,
+                     const glm::vec3& origin,
+                     float voxelSize,
+                     const glm::ivec3& gridDim) {
+    for (const Triangle& t : tris) {
+        glm::vec3 triMin = glm::min(t.v0, glm::min(t.v1, t.v2));
+        glm::vec3 triMax = glm::max(t.v0, glm::max(t.v1, t.v2));
+        glm::ivec3 minV = glm::floor((triMin - origin) / voxelSize);
+        glm::ivec3 maxV = glm::floor((triMax - origin) / voxelSize);
+        glm::ivec3 extent = maxV - minV + glm::ivec3(1);
+
+        VoxelizePush pc;
+        pc.v0 = t.v0;
+        pc.v1 = t.v1;
+        pc.v2 = t.v2;
+        pc.origin = origin;
+        pc.voxelSize = voxelSize;
+        pc.minVoxel = minV;
+        pc.gridDim = gridDim;
+
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &occupancySet, 0, nullptr);
+        vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(VoxelizePush), &pc);
+        vkCmdDispatch(cmd, static_cast<uint32_t>(extent.x),
+                           static_cast<uint32_t>(extent.y),
+                           static_cast<uint32_t>(extent.z));
+    }
+}
+
+} // namespace voxelvk

--- a/tests/test_capsule_ground.py
+++ b/tests/test_capsule_ground.py
@@ -9,16 +9,12 @@ import pytest
 
 @dataclass
 class CapsulePy:
-    """Simple vertical capsule used for Python collision checks."""
-
     center: np.ndarray
     half_height: float
     radius: float
 
 
 def resolve_capsule_world(cap: CapsulePy, world) -> tuple[np.ndarray, bool]:
-    """Push the capsule upward if it intersects the ground."""
-
     off = np.zeros(3, dtype=np.float32)
     bottom = cap.center[1] - (cap.half_height + cap.radius)
     ground = False
@@ -31,8 +27,6 @@ def resolve_capsule_world(cap: CapsulePy, world) -> tuple[np.ndarray, bool]:
 
 
 class DummyWorld:
-    """World with solid blocks below ``y == 0``."""
-
     def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
         return 1 if y < 0.0 else 0
 
@@ -45,20 +39,18 @@ def _load_cpp_lib() -> ctypes.CDLL:
     try:
         if not LIB_PATH.exists():
             src = ROOT / "src/physics_cpp/physics_c_api.cpp"
-            subprocess.check_call(
-                [
-                    "g++",
-                    "-std=c++17",
-                    "-shared",
-                    "-fPIC",
-                    str(src),
-                    "-I" + str(ROOT / "src/physics_cpp"),
-                    "-o",
-                    str(LIB_PATH),
-                ]
-            )
+            subprocess.check_call([
+                "g++",
+                "-std=c++17",
+                "-shared",
+                "-fPIC",
+                str(src),
+                "-I" + str(ROOT / "src/physics_cpp"),
+                "-o",
+                str(LIB_PATH),
+            ])
         return ctypes.CDLL(str(LIB_PATH))
-    except (subprocess.CalledProcessError, OSError, FileNotFoundError):  # pragma: no cover - skip if compilation fails
+    except (subprocess.CalledProcessError, OSError, FileNotFoundError):  # pragma: no cover
         pytest.skip("physics_cpp library unavailable", allow_module_level=True)
 
 
@@ -78,16 +70,12 @@ lib.resolve_capsule_ground.restype = ctypes.c_int
 
 
 def test_capsule_ground_collision() -> None:
-    """Capsule should be pushed above the ground by both Python and C++ helpers."""
-
     world = DummyWorld()
 
-    # Python helper
     cap_py = CapsulePy(np.array([0.0, 0.2, 0.0], dtype=np.float32), 0.9, 0.3)
     off, ground = resolve_capsule_world(cap_py, world)
     assert ground and cap_py.center[1] >= 0.0, (off, cap_py.center, ground)
 
-    # C++ helper
     cap = Capsule(Vec3(0.0, 0.2, 0.0), 0.9, 0.3)
     off_c = Vec3()
     grounded = lib.resolve_capsule_ground(ctypes.byref(cap), ctypes.byref(off_c))
@@ -96,42 +84,5 @@ def test_capsule_ground_collision() -> None:
     assert off_c.y == pytest.approx(1.0, abs=1e-4)
 
 
-
-spec = importlib.util.find_spec("src.physics.capsule_voxel_sat")
-if spec is None:  # pragma: no cover - skip if module cannot be imported
-    pytest.skip("capsule_voxel_sat module unavailable", allow_module_level=True)
-try:
-    capsule_voxel_sat = importlib.import_module("src.physics.capsule_voxel_sat")
-except Exception:  # pragma: no cover - skip if module import fails
-    pytest.skip("capsule_voxel_sat module unavailable", allow_module_level=True)
-resolve_capsule_world = capsule_voxel_sat.resolve_capsule_world
-
-
-class DummyWorld:
-    def get_block_at_world_position(self, x, y, z):
-        return 1 if int(y) < 0 else 0  # ground at y=0
-
-
-def test_capsule_ground_collision():
-    world = DummyWorld()
-    cap = Capsule(
-        center=np.array([0.0, 0.2, 0.0], dtype=np.float32),
-        half_height=0.9,
-        radius=0.3,
-    )
-    off, ground = resolve_capsule_world(cap, world)
-    assert ground and cap.center[1] >= 0.0, (off, cap.center, ground)
-
-import pytest
-
-pytest.skip(
-    "capsule ground collision tests require native extensions not built in CI",
-    allow_module_level=True,
-)
-
-
-
-        main
-        main
-        main
-        main
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__])

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,4 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
->        main


### PR DESCRIPTION
## Summary
- Add voxelize_sat compute shader using triangle-AABB SAT test
- Dispatch SAT shader from C++ helper that iterates triangle voxels
- Restore physics helpers, tests, and lint configs so type checking and linting run

## Testing
- `pytest`
- `npx eslint .`
- `mypy .`
- `python tests/test_capsule_ground.py` (fails: Skipped: physics_cpp library unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68a38c742854832d95d69ae3c29be36d