### PR TITLE
Add sparse voxel octree utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,3 +159,11 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_layout.cpp)
 endif()
+
+# --- Sparse voxel octree ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE
+    src/world/svo_builder.cpp
+    src/world/svo_io.cpp
+    src/render/svo_traversal.cpp)
+endif()

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,37 +1,10 @@
 const js = require('@eslint/js');
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
   {
     ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-    ignores: [
-      '**/build/**',
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -43,12 +16,8 @@ module.exports = [
       'tests/**',
       'apps/**',
       'scripts/**',
-
-      '**/build/**'
-    ]
-
+      '**/build/**',
     ],
-        main
   },
   {
     languageOptions: {
@@ -58,37 +27,7 @@ module.exports = [
     },
     rules: {
       'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-
-
       semi: ['error', 'always'],
     },
   },
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-];
-
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,30 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
-exclude = (^src/physics/|tests/test_capsule_ground.py)
 explicit_package_bases = True
-
-
 exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main

--- a/src/render/svo_traversal.cpp
+++ b/src/render/svo_traversal.cpp
@@ -12,7 +12,10 @@ void TraverseSvo(const std::vector<SvoNode>& nodes,
     visit(node, level);
     for (int i = 0; i < 8; ++i) {
         if (node.childMask & (1u << i)) {
-            TraverseSvo(nodes, visit, node.children[i], level + 1);
+            uint32_t childIndex = node.children[i];
+            if (childIndex < nodes.size()) {
+                TraverseSvo(nodes, visit, childIndex, level + 1);
+            }
         }
     }
 }

--- a/src/render/svo_traversal.cpp
+++ b/src/render/svo_traversal.cpp
@@ -1,0 +1,21 @@
+#include "world/svo.hpp"
+
+namespace voxelvk {
+
+void TraverseSvo(const std::vector<SvoNode>& nodes,
+                 const std::function<void(const SvoNode&, int)>& visit,
+                 uint32_t index, int level) {
+    if (index >= nodes.size()) {
+        return;
+    }
+    const SvoNode& node = nodes[index];
+    visit(node, level);
+    for (int i = 0; i < 8; ++i) {
+        if (node.childMask & (1u << i)) {
+            TraverseSvo(nodes, visit, node.children[i], level + 1);
+        }
+    }
+}
+
+} // namespace voxelvk
+

--- a/src/world/svo.hpp
+++ b/src/world/svo.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace voxelvk {
+
+struct SvoNode {
+    uint32_t morton{0};
+    uint8_t childMask{0};
+    std::array<uint32_t, 8> children{}; // indices into node array
+};
+
+// Build an octree from leaf Morton codes (2x2x2 grouping)
+std::vector<SvoNode> BuildSvo(const std::vector<uint32_t>& leaves);
+
+// Serialize/deserialize octree
+void SaveSvo(const std::string& path, const std::vector<SvoNode>& nodes);
+std::vector<SvoNode> LoadSvo(const std::string& path);
+
+// Traverse octree (depth-first)
+void TraverseSvo(const std::vector<SvoNode>& nodes,
+                 const std::function<void(const SvoNode&, int)>& visit,
+                 uint32_t index = 0, int level = 0);
+
+} // namespace voxelvk
+

--- a/src/world/svo_builder.cpp
+++ b/src/world/svo_builder.cpp
@@ -1,0 +1,63 @@
+#include "svo.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+
+namespace voxelvk {
+
+static uint32_t ParentCode(uint32_t code) { return code >> 3; }
+static uint32_t ChildIndex(uint32_t code) { return code & 0x7; }
+
+std::vector<SvoNode> BuildSvo(const std::vector<uint32_t>& leaves) {
+    std::vector<uint32_t> current = leaves;
+    std::sort(current.begin(), current.end());
+
+    std::vector<SvoNode> nodes;
+    nodes.reserve(current.size() * 2); // rough estimate
+    std::unordered_map<uint32_t, uint32_t> indexMap;
+
+    // Create leaf nodes
+    for (uint32_t code : current) {
+        SvoNode n{};
+        n.morton = code;
+        n.childMask = 0;
+        n.children.fill(UINT32_MAX);
+        nodes.push_back(n);
+        indexMap[code] = static_cast<uint32_t>(nodes.size() - 1);
+    }
+
+    // Aggregate bottom-up
+    while (current.size() > 1) {
+        std::unordered_map<uint32_t, std::vector<uint32_t>> groups;
+        groups.reserve(current.size() / 8 + 1);
+        for (uint32_t code : current) {
+            groups[ParentCode(code)].push_back(code);
+        }
+
+        std::vector<uint32_t> parents;
+        parents.reserve(groups.size());
+        for (auto& kv : groups) {
+            SvoNode n{};
+            n.morton = kv.first;
+            n.childMask = 0;
+            n.children.fill(UINT32_MAX);
+            for (uint32_t child : kv.second) {
+                uint32_t idx = ChildIndex(child);
+                n.childMask |= 1u << idx;
+                n.children[idx] = indexMap[child];
+            }
+            nodes.push_back(n);
+            uint32_t nodeIndex = static_cast<uint32_t>(nodes.size() - 1);
+            indexMap[kv.first] = nodeIndex;
+            parents.push_back(kv.first);
+        }
+        current = std::move(parents);
+        std::sort(current.begin(), current.end());
+        current.erase(std::unique(current.begin(), current.end()), current.end());
+    }
+
+    return nodes;
+}
+
+} // namespace voxelvk
+

--- a/src/world/svo_io.cpp
+++ b/src/world/svo_io.cpp
@@ -26,6 +26,9 @@ std::vector<SvoNode> LoadSvo(const std::string& path) {
     }
     uint32_t count = 0;
     in.read(reinterpret_cast<char*>(&count), sizeof(count));
+    if (!in || in.gcount() != sizeof(count)) {
+        throw std::runtime_error("Failed to read SVO node count from file: " + path);
+    }
     std::vector<SvoNode> nodes(count);
     for (uint32_t i = 0; i < count; ++i) {
         SvoNode& n = nodes[i];

--- a/src/world/svo_io.cpp
+++ b/src/world/svo_io.cpp
@@ -34,7 +34,12 @@ std::vector<SvoNode> LoadSvo(const std::string& path) {
         SvoNode& n = nodes[i];
         in.read(reinterpret_cast<char*>(&n.morton), sizeof(n.morton));
         in.read(reinterpret_cast<char*>(&n.childMask), sizeof(n.childMask));
+        in.read(reinterpret_cast<char*>(&n.morton), sizeof(n.morton));
+        if (!in) throw std::runtime_error("File corrupted or truncated while reading morton value for node " + std::to_string(i) + " in " + path);
+        in.read(reinterpret_cast<char*>(&n.childMask), sizeof(n.childMask));
+        if (!in) throw std::runtime_error("File corrupted or truncated while reading childMask for node " + std::to_string(i) + " in " + path);
         in.read(reinterpret_cast<char*>(n.children.data()), sizeof(uint32_t) * 8);
+        if (!in) throw std::runtime_error("File corrupted or truncated while reading children for node " + std::to_string(i) + " in " + path);
     }
     return nodes;
 }

--- a/src/world/svo_io.cpp
+++ b/src/world/svo_io.cpp
@@ -1,0 +1,40 @@
+#include "svo.hpp"
+
+#include <fstream>
+#include <stdexcept>
+
+namespace voxelvk {
+
+void SaveSvo(const std::string& path, const std::vector<SvoNode>& nodes) {
+    std::ofstream out(path, std::ios::binary);
+    if (!out) {
+        throw std::runtime_error("Failed to open file for writing: " + path);
+    }
+    uint32_t count = static_cast<uint32_t>(nodes.size());
+    out.write(reinterpret_cast<const char*>(&count), sizeof(count));
+    for (const auto& n : nodes) {
+        out.write(reinterpret_cast<const char*>(&n.morton), sizeof(n.morton));
+        out.write(reinterpret_cast<const char*>(&n.childMask), sizeof(n.childMask));
+        out.write(reinterpret_cast<const char*>(n.children.data()), sizeof(uint32_t) * 8);
+    }
+}
+
+std::vector<SvoNode> LoadSvo(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("Failed to open file for reading: " + path);
+    }
+    uint32_t count = 0;
+    in.read(reinterpret_cast<char*>(&count), sizeof(count));
+    std::vector<SvoNode> nodes(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        SvoNode& n = nodes[i];
+        in.read(reinterpret_cast<char*>(&n.morton), sizeof(n.morton));
+        in.read(reinterpret_cast<char*>(&n.childMask), sizeof(n.childMask));
+        in.read(reinterpret_cast<char*>(n.children.data()), sizeof(uint32_t) * 8);
+    }
+    return nodes;
+}
+
+} // namespace voxelvk
+

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,4 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
->        main


### PR DESCRIPTION
## Summary
- build octree nodes bottom-up using Morton codes
- serialize and load SVO trees from disk
- traverse SVO trees with depth-first visitor

## Testing
- `npx eslint .`
- `mypy src`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a38c72240c832d88c0f3127d3e0441