### PR TITLE
Add voxelization pass with conservative rasterization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,11 @@ if(TARGET VoxelVK_Elite_ALL)
     src/render/csm_pass.cpp)
 endif()
 
+# --- Voxelization pass ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_pass.cpp)
+endif()
+
 # --- CSM descriptor layout helper ---
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_layout.cpp)

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,37 +1,10 @@
 const js = require('@eslint/js');
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
   {
     ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-    ignores: [
-      '**/build/**',
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -43,52 +16,18 @@ module.exports = [
       'tests/**',
       'apps/**',
       'scripts/**',
-
       '**/build/**'
     ]
-
-    ],
-        main
   },
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
+      globals: { ...globals.node, ...globals.es2021 }
     },
     rules: {
       'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
       'semi': ['error', 'always']
     }
   }
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
 ];
-
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,30 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
-exclude = (^src/physics/|tests/test_capsule_ground.py)
 explicit_package_bases = True
-
-
 exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main

--- a/shaders_vk/voxelize/voxelize.frag.glsl
+++ b/shaders_vk/voxelize/voxelize.frag.glsl
@@ -1,0 +1,14 @@
+#version 460
+#extension GL_EXT_conservative_rasterization : enable
+
+layout(set=0, binding=0, r8ui) uniform uimage3D uOccupancy;
+
+layout(push_constant) uniform Push {
+    mat4 uMVP;
+    int  uSlice;
+} pc;
+
+void main(){
+    ivec3 coord = ivec3(int(gl_FragCoord.x), int(gl_FragCoord.y), pc.uSlice);
+    imageAtomicOr(uOccupancy, coord, 1);
+}

--- a/shaders_vk/voxelize/voxelize.vert.glsl
+++ b/shaders_vk/voxelize/voxelize.vert.glsl
@@ -1,0 +1,13 @@
+#version 460
+#extension GL_EXT_conservative_rasterization : enable
+
+layout(location=0) in vec3 inPosition;
+
+layout(push_constant) uniform Push {
+    mat4 uMVP;
+    int  uSlice;
+} pc;
+
+void main(){
+    gl_Position = pc.uMVP * vec4(inPosition, 1.0);
+}

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -1,0 +1,227 @@
+#include "voxelize_pass.hpp"
+#include <stdexcept>
+#include <vector>
+#include <cstdio>
+
+#include "vk_mem_alloc.h"
+
+namespace voxelvk {
+
+static VkShaderModule loadShader(VkDevice dev, const char* path);
+
+uint32_t VoxelizePass::findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags){
+    VkPhysicalDeviceMemoryProperties memProps{};
+    vkGetPhysicalDeviceMemoryProperties(phys, &memProps);
+    for(uint32_t i=0;i<memProps.memoryTypeCount;i++){
+        if((typeBits & (1u<<i)) && (memProps.memoryTypes[i].propertyFlags & flags) == flags)
+            return i;
+    }
+    throw std::runtime_error("No suitable memory type");
+}
+
+bool VoxelizePass::init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc, uint32_t dimension){
+    device = dev; allocator = alloc; dim = dimension;
+    if(!createImage(phys)) return false;
+    if(!createDescriptors()) return false;
+    if(!createPipeline(phys)) return false;
+    return true;
+}
+
+void VoxelizePass::destroy(){
+    if(pipeline) vkDestroyPipeline(device, pipeline, nullptr);
+    if(pipelineLayout) vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+    if(descSet) {}
+    if(descPool) vkDestroyDescriptorPool(device, descPool, nullptr);
+    if(setLayout) vkDestroyDescriptorSetLayout(device, setLayout, nullptr);
+    if(voxelView) vkDestroyImageView(device, voxelView, nullptr);
+    if(voxelImage) vmaDestroyImage(allocator, voxelImage, voxelAlloc);
+}
+
+bool VoxelizePass::createImage(VkPhysicalDevice phys){
+    VkImageCreateInfo ci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+    ci.imageType = VK_IMAGE_TYPE_3D;
+    ci.format = voxelFormat;
+    ci.extent = {dim, dim, dim};
+    ci.mipLevels = 1;
+    ci.arrayLayers = 1;
+    ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    ci.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    if(vmaCreateImage(allocator, &ci, &aci, &voxelImage, &voxelAlloc, nullptr) != VK_SUCCESS)
+        return false;
+
+    VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
+    vci.image = voxelImage;
+    vci.viewType = VK_IMAGE_VIEW_TYPE_3D;
+    vci.format = voxelFormat;
+    vci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    vci.subresourceRange.levelCount = 1;
+    vci.subresourceRange.layerCount = 1;
+    return vkCreateImageView(device, &vci, nullptr, &voxelView) == VK_SUCCESS;
+}
+
+bool VoxelizePass::createDescriptors(){
+    VkDescriptorSetLayoutBinding b{};
+    b.binding = 0;
+    b.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    b.descriptorCount = 1;
+    b.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    VkDescriptorSetLayoutCreateInfo lci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+    lci.bindingCount = 1; lci.pBindings = &b;
+    if(vkCreateDescriptorSetLayout(device, &lci, nullptr, &setLayout) != VK_SUCCESS) return false;
+
+    VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps.descriptorCount = 1;
+    VkDescriptorPoolCreateInfo pci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+    pci.maxSets = 1; pci.poolSizeCount = 1; pci.pPoolSizes = &ps;
+    if(vkCreateDescriptorPool(device, &pci, nullptr, &descPool) != VK_SUCCESS) return false;
+
+    VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+    ai.descriptorPool = descPool; ai.descriptorSetCount = 1; ai.pSetLayouts = &setLayout;
+    if(vkAllocateDescriptorSets(device, &ai, &descSet) != VK_SUCCESS) return false;
+
+    VkDescriptorImageInfo ii{}; ii.imageView = voxelView; ii.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    VkWriteDescriptorSet w{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
+    w.dstSet = descSet; w.dstBinding = 0; w.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    w.descriptorCount = 1; w.pImageInfo = &ii;
+    vkUpdateDescriptorSets(device, 1, &w, 0, nullptr);
+    return true;
+}
+
+bool VoxelizePass::createPipeline(VkPhysicalDevice phys){
+    VkShaderModule vs = loadShader(device, "spv/voxelize/voxelize.vert.spv");
+    VkShaderModule fs = loadShader(device, "spv/voxelize/voxelize.frag.spv");
+    if(!vs || !fs) return false;
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = vs;
+    stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = fs;
+    stages[1].pName = "main";
+
+    VkVertexInputBindingDescription bind{};
+    bind.binding = 0; bind.stride = sizeof(glm::vec3); bind.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputAttributeDescription attr{};
+    attr.location = 0; attr.binding = 0; attr.format = VK_FORMAT_R32G32B32_SFLOAT; attr.offset = 0;
+    VkPipelineVertexInputStateCreateInfo vi{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vi.vertexBindingDescriptionCount = 1; vi.pVertexBindingDescriptions = &bind;
+    vi.vertexAttributeDescriptionCount = 1; vi.pVertexAttributeDescriptions = &attr;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineRasterizationConservativeStateCreateInfoEXT cr{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT};
+    cr.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT;
+    cr.extraPrimitiveOverestimationSize = 0.0f;
+
+    VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rs.pNext = &cr; rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_NONE;
+    rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE; rs.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    ds.depthTestEnable = VK_FALSE; ds.depthWriteEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo cb{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+
+    VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn{VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dyn.dynamicStateCount = 2; dyn.pDynamicStates = dynStates;
+
+    VkPushConstantRange pcr{}; pcr.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
+    pcr.offset = 0; pcr.size = sizeof(glm::mat4) + sizeof(int);
+
+    VkPipelineLayoutCreateInfo lci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+    lci.setLayoutCount = 1; lci.pSetLayouts = &setLayout;
+    lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &pcr;
+    if(vkCreatePipelineLayout(device, &lci, nullptr, &pipelineLayout) != VK_SUCCESS){
+        vkDestroyShaderModule(device, vs, nullptr);
+        vkDestroyShaderModule(device, fs, nullptr);
+        return false;
+    }
+
+    VkPipelineRenderingCreateInfo rinfo{VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    rinfo.colorAttachmentCount = 0;
+    rinfo.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
+    rinfo.stencilAttachmentFormat = VK_FORMAT_UNDEFINED;
+
+    VkGraphicsPipelineCreateInfo pci{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pci.pNext = &rinfo;
+    pci.stageCount = 2; pci.pStages = stages;
+    pci.pVertexInputState = &vi;
+    pci.pInputAssemblyState = &ia;
+    pci.pRasterizationState = &rs;
+    pci.pMultisampleState = &ms;
+    pci.pDepthStencilState = &ds;
+    pci.pColorBlendState = &cb;
+    pci.pDynamicState = &dyn;
+    pci.layout = pipelineLayout;
+    pci.renderPass = VK_NULL_HANDLE;
+    pci.subpass = 0;
+
+    bool ok = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pci, nullptr, &pipeline) == VK_SUCCESS;
+    vkDestroyShaderModule(device, vs, nullptr);
+    vkDestroyShaderModule(device, fs, nullptr);
+    return ok;
+}
+
+void VoxelizePass::record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScene){
+    VkViewport vp{0,0,(float)dim,(float)dim,0.0f,1.0f};
+    VkRect2D sc{{0,0},{dim,dim}};
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descSet, 0, nullptr);
+    vkCmdSetViewport(cmd, 0, 1, &vp);
+    vkCmdSetScissor(cmd, 0, 1, &sc);
+
+    for(uint32_t z=0; z<dim; ++z){
+        struct Push { glm::mat4 mvp; int slice; } pc{};
+        pc.mvp = glm::mat4(1.0f);
+        pc.slice = (int)z;
+        vkCmdPushConstants(cmd, pipelineLayout,
+                           VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                           0, sizeof(Push), &pc);
+
+        VkRenderingInfo ri{VK_STRUCTURE_TYPE_RENDERING_INFO};
+        ri.renderArea = sc;
+        ri.layerCount = 1;
+        ri.colorAttachmentCount = 0;
+        vkCmdBeginRendering(cmd, &ri);
+        drawScene(cmd, (int)z);
+        vkCmdEndRendering(cmd);
+    }
+}
+
+static std::vector<char> readFile(const char* path){
+    std::vector<char> data;
+    FILE* f = std::fopen(path, "rb");
+    if(!f) return data;
+    std::fseek(f, 0, SEEK_END);
+    long n = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    data.resize(n);
+    std::fread(data.data(), 1, n, f);
+    std::fclose(f);
+    return data;
+}
+
+static VkShaderModule loadShader(VkDevice dev, const char* path){
+    auto bytes = readFile(path);
+    if(bytes.empty()) return VK_NULL_HANDLE;
+    VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+    ci.codeSize = bytes.size();
+    ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());
+    VkShaderModule m;
+    if(vkCreateShaderModule(dev, &ci, nullptr, &m) != VK_SUCCESS) return VK_NULL_HANDLE;
+    return m;
+}
+
+} // namespace voxelvk

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -18,7 +18,6 @@ uint32_t VoxelizePass::findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, 
     }
     throw std::runtime_error("No suitable memory type");
 }
-
 bool VoxelizePass::init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc, uint32_t dimension){
     device = dev; allocator = alloc; dim = dimension;
     if(!createImage(phys)) return false;

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -29,7 +29,7 @@ bool VoxelizePass::init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc,
 void VoxelizePass::destroy(){
     if(pipeline) vkDestroyPipeline(device, pipeline, nullptr);
     if(pipelineLayout) vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
-    if(descSet) {}
+    // Descriptor sets are freed when the descriptor pool is destroyed.
     if(descPool) vkDestroyDescriptorPool(device, descPool, nullptr);
     if(setLayout) vkDestroyDescriptorSetLayout(device, setLayout, nullptr);
     if(voxelView) vkDestroyImageView(device, voxelView, nullptr);

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -183,7 +183,7 @@ void VoxelizePass::record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScen
 
     for(uint32_t z=0; z<dim; ++z){
         Push pc{};
-        pc.mvp = glm::mat4(1.0f);
+        pc.mvp = mvp;
         pc.slice = (int)z;
         vkCmdPushConstants(cmd, pipelineLayout,
                            VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -182,7 +182,7 @@ void VoxelizePass::record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScen
     vkCmdSetScissor(cmd, 0, 1, &sc);
 
     for(uint32_t z=0; z<dim; ++z){
-        struct Push { glm::mat4 mvp; int slice; } pc{};
+        Push pc{};
         pc.mvp = glm::mat4(1.0f);
         pc.slice = (int)z;
         vkCmdPushConstants(cmd, pipelineLayout,

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -214,7 +214,10 @@ static std::vector<char> readFile(const char* path){
 
 static VkShaderModule loadShader(VkDevice dev, const char* path){
     auto bytes = readFile(path);
-    if(bytes.empty()) return VK_NULL_HANDLE;
+    if(bytes.empty()) {
+        std::fprintf(stderr, "Error: Failed to load shader file '%s'\n", path);
+        return VK_NULL_HANDLE;
+    }
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     ci.codeSize = bytes.size();
     ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());

--- a/src/render/voxelize_pass.hpp
+++ b/src/render/voxelize_pass.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <glm/glm.hpp>
+#include <functional>
+#include <cstdint>
+
+struct VmaAllocator_T;
+using VmaAllocator = VmaAllocator_T*;
+struct VmaAllocation_T;
+using VmaAllocation = VmaAllocation_T*;
+
+namespace voxelvk {
+
+using RecordVoxelDrawFn = std::function<void(VkCommandBuffer cmd, int slice)>;
+
+struct VoxelizePass {
+    VkDevice      device = VK_NULL_HANDLE;
+    VmaAllocator  allocator = nullptr;
+    uint32_t      dim = 0;
+    VkFormat      voxelFormat = VK_FORMAT_R8_UINT;
+
+    VkImage       voxelImage = VK_NULL_HANDLE;
+    VmaAllocation voxelAlloc = nullptr;
+    VkImageView   voxelView = VK_NULL_HANDLE;
+
+    VkDescriptorSetLayout setLayout = VK_NULL_HANDLE;
+    VkDescriptorPool      descPool = VK_NULL_HANDLE;
+    VkDescriptorSet       descSet = VK_NULL_HANDLE;
+
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    VkPipeline       pipeline = VK_NULL_HANDLE;
+
+    bool init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc, uint32_t dimension);
+    void destroy();
+
+    void record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScene);
+
+    VkImageView getVoxelView() const { return voxelView; }
+
+private:
+    bool createImage(VkPhysicalDevice phys);
+    bool createDescriptors();
+    bool createPipeline(VkPhysicalDevice phys);
+    uint32_t findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags);
+};
+
+} // namespace voxelvk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,4 +93,4 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
->        main
+


### PR DESCRIPTION
## Summary
- add voxelization shaders using conservative rasterization and atomic occupancy writes
- implement VoxelizePass pipeline to rasterize each voxel slice and bind storage image
- fix linting and type checking configs for clean runs

## Testing
- `npx eslint .`
- `pytest`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68a38c6f2bf4832dbfb08d43881bc069