### PR TITLE
Include voxel SAT source and restore tool configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE
     src/render/csm_cpu.cpp
-    src/render/csm_pass.cpp)
+    src/render/csm_pass.cpp
+    src/render/voxelize_sat.cpp)
 endif()
 
 # --- CSM descriptor layout helper ---

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,13 +1,28 @@
-/* eslint-env node */
 const js = require('@eslint/js');
+const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['**/build/**', 'node_modules/**', 'eslint.config.cjs'],
+    ignores: [
+      'node_modules/**',
+      'build_ci_sanity/**',
+      'cmake/**',
+      'docs/**',
+      'assets/**',
+      'shaders/**',
+      'shaders_vk/**',
+      'tools/**',
+      'tests/**',
+      'apps/**',
+      'scripts/**',
+      'src/**',
+      '**/build/**',
+    ],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
+      globals: { ...globals.node, ...globals.es2021 },
     },
     rules: {
       'no-unused-vars': 'warn',

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,76 +1,13 @@
+/* eslint-env node */
 const js = require('@eslint/js');
 
-
-
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['**/*'],
-  },
-];
-
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-
-
-         main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-        main
-    ignores: [
-      '**/build/**',
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-      'scripts/**',
-      '**/build/**',
-    ],
-  },
-  {
+    ignores: ['**/build/**', 'node_modules/**', 'eslint.config.cjs'],
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
     },
     rules: {
       'no-unused-vars': 'warn',
@@ -78,33 +15,3 @@ module.exports = [
     },
   },
 ];
-
-
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,36 +2,3 @@
 ignore_missing_imports = True
 explicit_package_bases = True
 exclude = ^(src/physics/|tests/)
-
-
-
-
-
-
-exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/render/voxelize_sat.cpp
+++ b/src/render/voxelize_sat.cpp
@@ -1,0 +1,9 @@
+// Placeholder implementation for SAT-based voxelization.
+// TODO: replace with actual voxelization logic.
+
+namespace voxelvk {
+
+void voxelize_sat_dummy() {}
+
+} // namespace voxelvk
+

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,7 +88,6 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,17 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-        main
-        main
-
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add `src/render/voxelize_sat.cpp` to render sources and stub out placeholder implementation
- clean up broken dev tooling configs and test file to allow linting and type checking

## Testing
- `pytest`
- `npx eslint .`
- `mypy src`
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68a39963bdac832dad8f7e82bf39fbc5