### PR TITLE
Add voxel SAT compute dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,3 +167,8 @@ if(TARGET VoxelVK_Elite_ALL)
     src/world/svo_io.cpp
     src/render/svo_traversal.cpp)
 endif()
+
+# --- Voxel SAT compute dispatch ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,5 +170,5 @@ endif()
 
 # --- Voxel SAT compute dispatch ---
 if(TARGET VoxelVK_Elite_ALL)
-  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp)
+  # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -34,6 +34,11 @@ if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE ${VOXELVK_ELITE_SOURCES})
 endif()
 
+# --- Voxel SAT compute dispatch ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp)
+endif()
+
 # --- BRDF LUT compute integration ---
 if(TARGET VoxelVK_Elite_ALL)
   set(VOXELVK_ELITE_SOURCES)

--- a/src/render/voxelize_sat.cpp
+++ b/src/render/voxelize_sat.cpp
@@ -25,7 +25,9 @@ void dispatch_voxelize_sat(VkCommandBuffer cmd,
     for (uint32_t i = 0; i < triangleCount; ++i) {
         vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(TrianglePC), &triangles[i]);
         vkCmdDispatch(cmd, 1, 1, 1);
-    }
+    // Triangle data should be uploaded to a storage buffer and bound via descriptorSet.
+    // The shader should index into the buffer using gl_GlobalInvocationID.x.
+    vkCmdDispatch(cmd, triangleCount, 1, 1);
 }
 
 } // namespace voxelvk

--- a/src/render/voxelize_sat.cpp
+++ b/src/render/voxelize_sat.cpp
@@ -1,0 +1,32 @@
+#include <vulkan/vulkan.h>
+#include <cstdint>
+
+namespace voxelvk {
+
+struct TrianglePC {
+    float v0[3];
+    float v1[3];
+    float v2[3];
+};
+
+void dispatch_voxelize_sat(VkCommandBuffer cmd,
+                           VkPipeline pipeline,
+                           VkPipelineLayout layout,
+                           VkDescriptorSet descriptorSet,
+                           const TrianglePC* triangles,
+                           uint32_t triangleCount) {
+    if (!cmd || !pipeline || !layout || !descriptorSet || !triangles || triangleCount == 0) {
+        return;
+    }
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &descriptorSet, 0, nullptr);
+
+    for (uint32_t i = 0; i < triangleCount; ++i) {
+        vkCmdPushConstants(cmd, layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(TrianglePC), &triangles[i]);
+        vkCmdDispatch(cmd, 1, 1, 1);
+    }
+}
+
+} // namespace voxelvk
+


### PR DESCRIPTION
## Summary
- integrate voxel SAT dispatch bindings and per-triangle push constants
- register voxel SAT dispatch in build scripts

## Testing
- `npm exec eslint .` *(fails: Unexpected identifier 'main' in eslint.config.cjs)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py:102)*
- `mypy` *(fails: duplicate 'exclude' option in mypy.ini)*
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68a39c238824832d99937b834838c930