### PR TITLE
chore: tidy player controller test and configs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -16,7 +16,6 @@ module.exports = [
       'tests/**',
       'apps/**',
       'scripts/**',
-      'node_modules/**',
       'src/**'
     ],
     languageOptions: {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,63 +1,11 @@
 const js = require('@eslint/js');
-
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: ['**/*'],
-  },
-];
-
-
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
-
-
-         main
-         main
-const globals = require('globals');
-module.exports = [
-  js.configs.recommended,
   {
-    ignores: [
-
-      '**/build/**',
-
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-        main
     ignores: [
       '**/build/**',
-        main
-        main
-        main
-        main
-      'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
@@ -67,16 +15,10 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
-      'scripts/**'
-    ],
-
       'scripts/**',
-      '**/build/**',
+      'node_modules/**',
+      'src/**'
     ],
-  },
-  {
-        main
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
@@ -84,44 +26,7 @@ module.exports = [
     },
     rules: {
       'no-unused-vars': 'warn',
-
       semi: ['error', 'always']
     }
   }
 ];
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main
-        main
-        main

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -16,7 +16,7 @@ module.exports = [
       'tests/**',
       'apps/**',
       'scripts/**',
-      'src/**'
+      'node_modules/**'
     ],
     languageOptions: {
       ecmaVersion: 2021,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,41 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 explicit_package_bases = True
-
 exclude = ^(src/physics/|tests/)
-
-exclude = ^(src/physics/|tests/)
-
-
-
-
-
-
-exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -93,19 +93,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-        main
-        main
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- remove leftover main strings from player controller capsule tests
- restore ESLint and mypy configurations

## Testing
- `pytest tests/test_player_controller_capsule.py`
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a3a61a52fc832da4738e68cc1b9785