### PR TITLE
Restore minimal ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,62 +1,15 @@
 const js = require('@eslint/js');
-
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: ['**/*'],
-  },
-];
-
-
-
 const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
-
-
-         main
-         main
-const globals = require('globals');
-module.exports = [
-  js.configs.recommended,
   {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+      globals: { ...globals.node, ...globals.es2021 },
+    },
     ignores: [
-
-      '**/build/**',
-
-
-
-const globals = require('globals');
-
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-module.exports = [js.configs.recommended];
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: ['node_modules/**', 'tests/**', 'src/**', 'docs/**'],
-  },
-
-        main
-        main
-    ignores: [
-      '**/build/**',
-        main
-        main
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -67,61 +20,9 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
-      'scripts/**'
-    ],
-
       'scripts/**',
       '**/build/**',
     ],
-  },
-  {
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-      semi: ['error', 'always'],
-    },
+    rules: { 'no-unused-vars': 'warn', semi: ['error', 'always'] },
   },
 ];
-
-
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-    },
-  },
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,41 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 explicit_package_bases = True
-
 exclude = ^(src/physics/|tests/)
-
-exclude = ^(src/physics/|tests/)
-
-
-
-
-
-
-exclude = ^(src/physics/|tests/)
-
-
-        main
-explicit_package_bases = True
-exclude = ^src/physics/
-
-
-
-
-exclude = ^src/physics/
-
-
-exclude = src/physics/.*
-
-exclude = ^src/physics/
-        main
-        main
-explicit_package_bases = True
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,24 +88,7 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-        main
-        main
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- Rebuild ESLint configuration with Node globals, ignore patterns and basic rules
- Clean up corrupted player controller capsule test so suite can skip cleanly
- Simplify mypy configuration for successful type checking

## Testing
- `npm exec eslint .`
- `pytest`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68a3a6176f00832d9edcaefd2b5863ca