### PR TITLE
Clean up capsule voxel SAT utilities

### DIFF
--- a/src/physics/__init__.py
+++ b/src/physics/__init__.py
@@ -1,37 +1,12 @@
-"""Shared helpers for player movement physics.
-
-These modules are retained for reference only. C++ equivalents live in
-``src/physics_cpp`` and should be preferred for production use.
-"""
-
-from __future__ import annotations
-
 from typing import Any
-
 import numpy as np
 
 
-# Multiplier applied to ``max_speed`` when sprint input is active.
 SPRINT_SPEED_MULTIPLIER = 1.6
 
 
 def get_horizontal_speed(player: Any) -> float:
-    """Return the horizontal speed of the player.
-
-    Parameters
-    ----------
-    player:
-        Object with a ``vel`` attribute representing velocity as a numpy array.
-        Only the X and Z components are considered.
-
-    Returns
-    -------
-    float
-        Magnitude of the horizontal velocity vector.
-    """
-
     return float(np.linalg.norm(player.vel[[0, 2]]))
 
 
 __all__ = ["SPRINT_SPEED_MULTIPLIER", "get_horizontal_speed"]
-

--- a/src/physics/capsule.py
+++ b/src/physics/capsule.py
@@ -1,118 +1,20 @@
-
 from __future__ import annotations
 
-
-from __future__ import annotations
-
-
-
-
 from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-        main
-
-        main
-
-        main
-        main
-        main
-        main
-"""Minimal capsule representation for tests."""
-
-
-@dataclass
-class Capsule:
-
-
-import numpy as np
-from dataclasses import dataclass
-
-from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-
-
-from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-
-        main
-from __future__ import annotations
-
-
-        main
-        main
-        main
-from dataclasses import dataclass
-import numpy as np
-from numpy.typing import NDArray
-
-import numpy as np
-        main
-from numpy.typing import NDArray
-        main
-        main
-
-import numpy as np
-from numpy.typing import NDArray
-
-import numpy as np
-from numpy.typing import NDArray
-
 import numpy as np
 from numpy.typing import NDArray
 
 
 @dataclass
 class Capsule:
+    """Vertical capsule defined by its center, half height and radius.
 
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-
-
-    """Simple vertical capsule defined by its center,
-    half-height, and radius."""
-    """
-    Represents a simple vertical capsule defined by its center, half-height, and radius.
-
-
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-    """Vertical capsule defined by its center, half-height, and radius."""
-
-  
-  
-    """Vertical capsule represented by a center point and radius.
-         main
-
-    Parameters
-    ----------
-    center : numpy.ndarray of shape (3,)
-        The center of the capsule (midpoint between the two spherical caps), in 3D space.
-    half_height : float
-        Half the height of the cylindrical part of the capsule (distance from center to cap center).
-    radius : float
-        The radius of the spherical caps and the cylinder.
+    The capsule is aligned along the Y axis.  ``center`` represents the middle
+    of the cylindrical part, ``half_height`` is the half length of this
+    cylinder and ``radius`` is the radius of the spherical caps and the
+    cylinder.
     """
 
-
-
-        main
-        main
-    """Simple vertical capsule defined by its center, half-height, and radius."""
-        main
-        main
-        main
-        main
-
-    center: NDArray[np.float32, Literal[3]]
-
-        main
-        main
     center: NDArray[np.float32]
     half_height: float
     radius: float
@@ -120,43 +22,16 @@ class Capsule:
     @property
     def seg_a(self) -> NDArray[np.float32]:
         """Center of the top spherical cap."""
-
-
-        return self.center + np.array([0.0, self.half_height, 0.0], dtype=np.float32)
-
         return self.center + np.array(
             [0.0, self.half_height, 0.0], dtype=np.float32
         )
-         main
 
     @property
     def seg_b(self) -> NDArray[np.float32]:
         """Center of the bottom spherical cap."""
-
-
-        return self.center - np.array([0.0, self.half_height, 0.0], dtype=np.float32)
-
         return self.center - np.array(
             [0.0, self.half_height, 0.0], dtype=np.float32
         )
-        main
 
 
 __all__ = ["Capsule"]
-
-
-
-
-
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -116,7 +116,7 @@ def resolve_capsule_world(
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n[1] > 0.7:
+        if hit_n is not None and hit_n[1] > 0.7:
             ground = True
     return total_offset, ground
 

--- a/src/physics/capsule_voxel_sat.py
+++ b/src/physics/capsule_voxel_sat.py
@@ -1,25 +1,8 @@
+from __future__ import annotations
 
 """Collision helpers for a capsule against a voxel world using SAT tests."""
 
-from __future__ import annotations
-
 from typing import Optional, Protocol, Tuple, cast
-
-
-"""Collision helpers for a capsule against a voxel world."""
-
-
-"""Capsule to voxel collision helpers used in tests."""
-
-from __future__ import annotations
-
-from typing import Any, Optional, Protocol, Tuple, cast
-        main
-        main
-
-from __future__ import annotations
-
-from typing import Protocol, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -29,61 +12,45 @@ from .voxel_solid import is_solid
 
 
 class WorldProtocol(Protocol):
-
-    """Minimal protocol required from the voxel world used in tests."""
-
     """Minimal protocol expected from the world used in tests."""
 
     def get_block_at_world_position(self, x: float, y: float, z: float) -> int:
+        """Return the block type at the given world position."""
         ...
 
-        main
-
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[np.ndarray, np.ndarray]:
 
 def closest_point_on_aabb(
-    p: NDArray[np.float32], mn: NDArray[np.float32], mx: NDArray[np.float32]
+    p: NDArray[np.float32],
+    mn: NDArray[np.float32],
+    mx: NDArray[np.float32],
 ) -> NDArray[np.float32]:
-
-    """Return the closest point on the axis-aligned box defined by ``mn`` and ``mx``."""
-
-    return np.minimum(np.maximum(p, mn), mx)
-
-    """Clamp point ``p`` to the axis-aligned box defined by ``mn`` and ``mx``."""
-    
-        main
-
+    """Return the closest point on the AABB defined by ``mn`` and ``mx``."""
     return cast(NDArray[np.float32], np.minimum(np.maximum(p, mn), mx))
 
 
-
-
-    return np.minimum(np.maximum(p, mn), mx)
-
-
-        main
-        main
 def closest_point_on_segment(
-    p: NDArray[np.float32], a: NDArray[np.float32], b: NDArray[np.float32]
+    p: NDArray[np.float32],
+    a: NDArray[np.float32],
+    b: NDArray[np.float32],
 ) -> NDArray[np.float32]:
-    """Return the closest point on the segment ``ab`` to ``p``."""
-
+    """Return the closest point on segment ``ab`` to point ``p``."""
     ab = b - a
     t = float(np.dot(p - a, ab) / (np.dot(ab, ab) + 1e-9))
     return cast(NDArray[np.float32], a + np.clip(t, 0.0, 1.0) * ab)
 
 
 def capsule_box_penetration(
-    cap: Capsule, mn: NDArray[np.float32], mx: NDArray[np.float32]
+    cap: Capsule,
+    mn: NDArray[np.float32],
+    mx: NDArray[np.float32],
 ) -> Tuple[bool, Optional[NDArray[np.float32]], float]:
-    """Check penetration of ``cap`` against an axis-aligned box."""
+    """Check penetration of ``cap`` against an axis-aligned box.
 
-
-
-
-        main
-        main
+    Returns
+    -------
+    tuple
+        ``(hit, normal, penetration_depth)``
+    """
     box_center = (mn + mx) * 0.5
     q_seg = closest_point_on_segment(box_center, cap.seg_a, cap.seg_b)
     q_box = closest_point_on_aabb(q_seg, mn, mx)
@@ -91,98 +58,52 @@ def capsule_box_penetration(
     dist = float(np.linalg.norm(v))
     pen = cap.radius - dist
     if pen > 0.0:
-
-        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0, 1, 0], dtype=np.float32)
-
+        normal = (
+            v / (dist + 1e-9)
+            if dist > 1e-9
+            else np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        )
         return True, cast(NDArray[np.float32], normal), float(pen)
     return False, None, 0.0
 
 
-        normal = v / (dist + 1e-9) if dist > 1e-9 else np.array([0.0, 1.0, 0.0], dtype=np.float32)
-        main
-        return True, cast(NDArray[np.float32], normal), float(pen)
-    return False, None, 0.0
-
-
-        main
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[NDArray[np.int_], NDArray[np.int_]]:
+def compute_capsule_voxel_bounds(
+    cap: Capsule,
+) -> Tuple[NDArray[np.int_], NDArray[np.int_]]:
     """Return integer min/max voxel coordinates overlapped by ``cap``."""
-
-def compute_capsule_voxel_bounds(cap: Capsule) -> Tuple[NDArray[np.int32], NDArray[np.int32]]:
-        main
-    """Return integer min/max voxel coordinates overlapped by ``cap``."""
-
-    mn = cap.center - np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    mx = cap.center + np.array([cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32)
-    return np.floor(mn).astype(np.int32), np.floor(mx).astype(np.int32)
-        main
-        main
-
     mn = cap.center - np.array(
-        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
     )
     mx = cap.center + np.array(
-        [cap.radius, cap.half_height + cap.radius, cap.radius], dtype=np.float32
+        [cap.radius, cap.half_height + cap.radius, cap.radius],
+        dtype=np.float32,
     )
     return np.floor(mn).astype(int), np.floor(mx).astype(int)
 
 
-
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> tuple[NDArray[np.float32], bool]:
-    """Keep ``cap`` above solid blocks in ``world`` and report displacement and ground state."""
-
-
-def resolve_capsule_world(cap: Capsule, world: WorldProtocol) -> tuple[np.ndarray, bool]:
-    """Very small helper used in tests to keep the capsule above solid blocks."""
-        main
-    off = np.zeros(3, dtype=np.float32)
-    ground = False
-    mn, mx = compute_capsule_voxel_bounds(cap)
-    for y in range(mn[1], mx[1] + 1):
-        for z in range(mn[2], mx[2] + 1):
-            for x in range(mn[0], mx[0] + 1):
-                if not is_solid(world.get_block_at_world_position(float(x), float(y), float(z))):
-                    continue
-                block_top = y + 1.0
-                bottom = cap.center[1] - (cap.half_height + cap.radius)
-                if bottom < block_top:
-                    delta = block_top - bottom
-                    cap.center[1] += delta
-                    off[1] += delta
-                    ground = True
-    return off, ground
-
-        main
-
 def resolve_capsule_world(
-    cap: Capsule, world: WorldProtocol, max_iters: int = 8
+    cap: Capsule,
+    world: WorldProtocol,
+    max_iters: int = 8,
 ) -> Tuple[NDArray[np.float32], bool]:
-    """Resolve ``cap`` against the voxel ``world`` and return total offset and ground state."""
+    """Resolve ``cap`` against the voxel ``world``.
 
-
-__all__ = ["WorldProtocol", "compute_capsule_voxel_bounds", "resolve_capsule_world"]
-
-
-def resolve_capsule_world(
-    cap: Capsule, world: WorldProtocol, max_iters: int = 8
-) -> Tuple[NDArray[np.float32], bool]:
-    """Resolve capsule against the voxel ``world`` and return total offset and ground state."""
-    total_offset = np.zeros(3, dtype=np.float32)
-    ground = False
-        main
-
+    Returns the total offset applied and whether the capsule ended on the
+    ground.
+    """
     total_offset = np.zeros(3, dtype=np.float32)
     ground = False
     for _ in range(max_iters):
         bb_min, bb_max = compute_capsule_voxel_bounds(cap)
-
         max_pen = 0.0
         hit_n: Optional[NDArray[np.float32]] = None
         for y in range(bb_min[1] - 1, bb_max[1] + 2):
             for z in range(bb_min[2] - 1, bb_max[2] + 2):
                 for x in range(bb_min[0] - 1, bb_max[0] + 2):
-                    bt = world.get_block_at_world_position(float(x), float(y), float(z))
+                    bt = world.get_block_at_world_position(
+                        float(x), float(y), float(z)
+                    )
                     if not is_solid(bt):
                         continue
                     mnv = np.array([x, y, z], dtype=np.float32)
@@ -195,13 +116,11 @@ def resolve_capsule_world(
         off = hit_n * max_pen
         cap.center += off
         total_offset += off
-        if hit_n is not None and hit_n[1] > 0.7:
+        if hit_n[1] > 0.7:
             ground = True
-
     return total_offset, ground
 
 
->        main
 __all__ = [
     "WorldProtocol",
     "closest_point_on_aabb",
@@ -210,10 +129,3 @@ __all__ = [
     "compute_capsule_voxel_bounds",
     "resolve_capsule_world",
 ]
-
-
-
-
-        main
-        main
-        main

--- a/src/physics/voxel_solid.py
+++ b/src/physics/voxel_solid.py
@@ -1,51 +1,22 @@
+from __future__ import annotations
 
 """Utilities to query whether a voxel block type is solid."""
-
-from __future__ import annotations
-
-
-"""Utilities to query whether a voxel block type is solid."""
-
-from __future__ import annotations
-
-
-"""Utilities to query whether a voxel block type is solid."""
-
-from __future__ import annotations
-         main
-
-from __future__ import annotations
-
-from typing import Dict
-        main
-        main
 
 from typing import Dict
 
 
-        main
 class BlockType:
     """Enumeration of built-in block types used in tests."""
 
     AIR = 0
 
 
-
 # Registry describing block properties. Games can populate this as needed.
-
-
-# Adapt this to your engine's block registry
 BLOCK_PROPERTIES: Dict[int, Dict[str, bool]] = {}
-
-# Simple registry mapping block type IDs to property dictionaries.
-        main
-BLOCK_PROPERTIES: Dict[int, dict] = {}
-        main
 
 
 def is_solid(block_type: int) -> bool:
     """Return ``True`` if ``block_type`` represents a solid block."""
-
     props = BLOCK_PROPERTIES.get(block_type)
     if props is None:
         return block_type != BlockType.AIR
@@ -53,11 +24,3 @@ def is_solid(block_type: int) -> bool:
 
 
 __all__ = ["BlockType", "BLOCK_PROPERTIES", "is_solid"]
-
-
-
-
-
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- refactor capsule to voxel collision helpers with clear functions and unique exports
- simplify capsule and block helper modules used by tests
- provide minimal package exports for physics helpers

## Testing
- `pytest -q`
- `flake8 src/physics/capsule_voxel_sat.py src/physics/capsule.py src/physics/voxel_solid.py src/physics/__init__.py`
- `mypy src/physics/capsule_voxel_sat.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3ad08ae78832d87fbd0f791e6c2ee