### PR TITLE
Fetch external libraries via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ FetchContent_Declare(
 set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
 set(LZ4_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(lz4)
-add_library(lz4 ALIAS lz4_static)
+add_library(lz4_lib ALIAS lz4_static)
 
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ FetchContent_Declare(
 set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "" FORCE)
 set(ZSTD_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(zstd)
-add_library(zstd ALIAS libzstd_static)
+add_library(zstd_lib ALIAS libzstd_static)
 
 # lz4 compression
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,43 @@ else()
 endif()
 find_package(Threads REQUIRED)
 
+# --- External dependencies ---
+include(FetchContent)
+
+# Vulkan Memory Allocator
+FetchContent_Declare(
+  vma
+  GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+  GIT_TAG v3.0.1
+)
+FetchContent_Populate(vma)
+add_library(vma INTERFACE)
+target_include_directories(vma INTERFACE ${vma_SOURCE_DIR}/src)
+
+# zstd compression
+FetchContent_Declare(
+  zstd
+  GIT_REPOSITORY https://github.com/facebook/zstd.git
+  GIT_TAG v1.5.5
+  SOURCE_SUBDIR build/cmake
+)
+set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "" FORCE)
+set(ZSTD_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(zstd)
+add_library(zstd ALIAS libzstd_static)
+
+# lz4 compression
+FetchContent_Declare(
+  lz4
+  GIT_REPOSITORY https://github.com/lz4/lz4.git
+  GIT_TAG v1.9.4
+  SOURCE_SUBDIR build/cmake
+)
+set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
+set(LZ4_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(lz4)
+add_library(lz4 ALIAS lz4_static)
+
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")
 if(ENABLE_VULKAN)
@@ -113,12 +150,17 @@ if(ENABLE_VULKAN)
   add_executable(smoke_headless apps/smoke_headless.cpp)
   add_dependencies(smoke_headless VoxelVK_Shaders)
   target_include_directories(smoke_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB})
+  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB} vma zstd lz4)
   target_compile_definitions(smoke_headless PRIVATE
     $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
     $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>
     $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
     $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+endif()
+
+# Link external libraries to main renderer if present
+if(TARGET VoxelVK_Elite_ALL)
+  target_link_libraries(VoxelVK_Elite_ALL PRIVATE vma zstd lz4)
 endif()
 
 # Tests

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -16,6 +16,10 @@ set_target_properties(smoke_graphics_headless PROPERTIES CXX_STANDARD 17 CXX_STA
 target_include_directories(smoke_graphics_headless PRIVATE ${CMAKE_BINARY_DIR}/generated)
 target_link_libraries(smoke_graphics_headless PRIVATE Vulkan::Vulkan)
 
+if(TARGET VoxelVK_Elite_ALL)
+  target_link_libraries(VoxelVK_Elite_ALL PRIVATE vma zstd lz4)
+endif()
+
 # --- Build tagging sources ---
 list(APPEND VOXELVK_ELITE_SOURCES
   src/core/build_info_print.cpp
@@ -39,7 +43,6 @@ if(TARGET VoxelVK_Elite_ALL)
   set(VOXELVK_ELITE_SOURCES)
   list(APPEND VOXELVK_ELITE_SOURCES src/render/ibl_brdf.cpp)
   target_sources(VoxelVK_Elite_ALL PRIVATE ${VOXELVK_ELITE_SOURCES})
-  target_include_directories(VoxelVK_Elite_ALL PRIVATE ${CMAKE_SOURCE_DIR}/external/vma)
 endif()
 
 # --- SDF generator staging pipeline ---
@@ -47,7 +50,6 @@ if(TARGET VoxelVK_Elite_ALL)
   set(VOXELVK_ELITE_SOURCES)
   list(APPEND VOXELVK_ELITE_SOURCES src/render/sdf_generator.cpp)
   target_sources(VoxelVK_Elite_ALL PRIVATE ${VOXELVK_ELITE_SOURCES})
-  target_include_directories(VoxelVK_Elite_ALL PRIVATE ${CMAKE_SOURCE_DIR}/external/vma)
 endif()
 
 add_custom_target(mirror_spv_ibl ALL

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,21 +1,15 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
 module.exports = [
   js.configs.recommended,
   {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+      globals: { ...globals.node, ...globals.es2021 }
+    },
     ignores: [
-
-
-
-
       'build/**',
       'node_modules/',
       'build_ci_sanity/',
@@ -30,204 +24,9 @@ module.exports = [
       'apps/',
       'scripts/'
     ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-
-      'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
     rules: {
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
   }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -101,24 +101,3 @@ pytest.skip(
 
 
 
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- use CMake FetchContent to download VMA, zstd, and lz4
- link new dependencies to renderer targets
- clean up lint and type-check configs and stray test lines so checks run

## Testing
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42cf479f4832db18b3fd72191fd1e