### PR TITLE
Fetch compression libraries and add build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,42 @@ else()
 endif()
 find_package(Threads REQUIRED)
 
+# ---- Compression libraries ----
+include(FetchContent)
+
+set(VOXELVK_HAS_ZSTD 0)
+find_package(ZSTD QUIET)
+if(ZSTD_FOUND)
+  set(VOXELVK_HAS_ZSTD 1)
+  set(ZSTD_TARGET ZSTD::ZSTD)
+else()
+  FetchContent_Declare(zstd URL https://github.com/facebook/zstd/archive/refs/tags/v1.5.6.tar.gz)
+  FetchContent_MakeAvailable(zstd)
+  set(VOXELVK_HAS_ZSTD 1)
+  set(ZSTD_TARGET zstd)
+endif()
+
+set(VOXELVK_HAS_LZ4 0)
+find_package(LZ4 QUIET)
+if(LZ4_FOUND)
+  set(VOXELVK_HAS_LZ4 1)
+  set(LZ4_TARGET LZ4::lz4)
+else()
+  FetchContent_Declare(lz4 URL https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz)
+  FetchContent_MakeAvailable(lz4)
+  set(VOXELVK_HAS_LZ4 1)
+  set(LZ4_TARGET lz4)
+endif()
+
+add_compile_definitions(
+  VOXELVK_HAS_ZSTD=${VOXELVK_HAS_ZSTD}
+  VOXELVK_HAS_LZ4=${VOXELVK_HAS_LZ4}
+)
+
+if(TARGET VoxelVK_Elite_ALL)
+  target_link_libraries(VoxelVK_Elite_ALL PRIVATE ${ZSTD_TARGET} ${LZ4_TARGET})
+endif()
+
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")
 if(ENABLE_VULKAN)

--- a/src/world/persistence.cpp
+++ b/src/world/persistence.cpp
@@ -6,18 +6,18 @@
 #include <algorithm>
 #include <iostream>
 
-#if __has_include(<zstd.h>)
-#define VOXELVK_HAS_ZSTD 1
-#include <zstd.h>
-#else
+#ifndef VOXELVK_HAS_ZSTD
 #define VOXELVK_HAS_ZSTD 0
 #endif
+#if VOXELVK_HAS_ZSTD
+#include <zstd.h>
+#endif
 
-#if __has_include(<lz4frame.h>)
-#define VOXELVK_HAS_LZ4 1
-#include <lz4frame.h>
-#else
+#ifndef VOXELVK_HAS_LZ4
 #define VOXELVK_HAS_LZ4 0
+#endif
+#if VOXELVK_HAS_LZ4
+#include <lz4frame.h>
 #endif
 
 namespace world {

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -1,22 +1,20 @@
 
 import json
 import logging
+import os
 import numpy as np
 from pathlib import Path
 from typing import Dict, Optional
 from concurrent.futures import Future, ThreadPoolExecutor
 from .rle import rle_encode, rle_decode
 
-try:
-    import zstandard as zstd
-    has_zstd=True
-except Exception:
-    has_zstd=False
-try:
-    import lz4.frame as lz4f
-    has_lz4=True
-except Exception:
-    has_lz4=False
+VOXELVK_HAS_ZSTD = os.getenv("VOXELVK_HAS_ZSTD") == "1"
+if VOXELVK_HAS_ZSTD:
+    import zstandard as zstd  # type: ignore
+
+VOXELVK_HAS_LZ4 = os.getenv("VOXELVK_HAS_LZ4") == "1"
+if VOXELVK_HAS_LZ4:
+    import lz4.frame as lz4f  # type: ignore
 
 class ChunkStore:
     def __init__(self, root="world_save", codec="zstd", use_rle=True, threads=4):
@@ -30,16 +28,16 @@ class ChunkStore:
     def chunk_path(self, cx, cz): return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
 
     def _compress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
+        if self.codec=="zstd" and VOXELVK_HAS_ZSTD:
             c = zstd.ZstdCompressor(level=10); return c.compress(b)
-        if self.codec=="lz4" and has_lz4:
+        if self.codec=="lz4" and VOXELVK_HAS_LZ4:
             return lz4f.compress(b, compression_level=9, block_size=lz4f.BLOCKSIZE_MAX1MB, content_checksum=True)
         return b
 
     def _decompress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
+        if self.codec=="zstd" and VOXELVK_HAS_ZSTD:
             d = zstd.ZstdDecompressor(); return d.decompress(b)
-        if self.codec=="lz4" and has_lz4:
+        if self.codec=="lz4" and VOXELVK_HAS_LZ4:
             return lz4f.decompress(b)
         return b
 


### PR DESCRIPTION
## Summary
- Fetch zstd and lz4 with CMake FetchContent and expose VOXELVK_HAS_ZSTD/LZ4 defines
- Replace __has_include checks with build flag macros in persistence.cpp
- Use environment-driven compression flags in persistence.py

## Testing
- `npx eslint .` *(fails: Unexpected token in eslint.config.cjs)*
- `mypy src` *(fails: option 'exclude' already exists in mypy.ini)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d08bfc4832db8b12db8a987bc9e