### PR TITLE
Add chunk manifest and compaction utilities

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,51 +1,4 @@
 const js = require('@eslint/js');
-const globals = require('globals');
-
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
 
 module.exports = [
   js.configs.recommended,
@@ -53,51 +6,11 @@ module.exports = [
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { require: 'readonly', module: 'readonly' },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
+      'build/**',
       'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
@@ -106,128 +19,10 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
-      'scripts/**',
-    ],
-
-
       'scripts/**'
     ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
-    },
   },
 ];
 
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,4 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
-files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
+files = src tests
 exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = tests/test_player_controller_capsule.py
+testpaths = tests/test_player_controller_capsule.py tests/test_persistence_manifest.py

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -20,10 +20,20 @@ except Exception:
 
 class ChunkStore:
     def __init__(self, root="world_save", codec="zstd", use_rle=True, threads=4):
-        self.root = Path(root); self.root.mkdir(parents=True, exist_ok=True)
-        self.codec = codec; self.use_rle = use_rle
-        self.pool = ThreadPoolExecutor(max_workers=max(1,threads))
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.codec = codec
+        self.use_rle = use_rle
+        self.pool = ThreadPoolExecutor(max_workers=max(1, threads))
         self.futures: Dict[str, Future] = {}
+        self.manifest_path = self.root / "manifest.json"
+        if self.manifest_path.exists():
+            try:
+                self.manifest = json.loads(self.manifest_path.read_text())
+            except Exception:
+                self.manifest = {}
+        else:
+            self.manifest = {}
 
     def _region_dir(self, cx, cz):
         d = self.root / f"r.{cx//32}.{cz//32}"; d.mkdir(exist_ok=True); return d
@@ -56,7 +66,8 @@ class ChunkStore:
                 header = np.array([vox.shape[0], vox.shape[1], vox.shape[2], 0, 0], dtype=np.int32).tobytes()
                 data = header + vox.tobytes()
             blob = self._compress(data)
-            self.chunk_path(cx, cz).write_bytes(blob)
+            path = self.chunk_path(cx, cz)
+            path.write_bytes(blob)
             idx = self._region_dir(cx, cz) / "index.json"
             table = {}
             if idx.exists():
@@ -66,6 +77,12 @@ class ChunkStore:
                     table = {}
             table[f"{cx},{cz}"] = {"saved": True}
             idx.write_text(json.dumps(table))
+            region = f"r.{cx//32}.{cz//32}"
+            entry = self.manifest.get(region, {"codec": self.codec, "chunks": {}})
+            entry["codec"] = self.codec
+            entry["chunks"][f"{cx},{cz}"] = {"offset": 0}
+            self.manifest[region] = entry
+            self.manifest_path.write_text(json.dumps(self.manifest))
         except Exception as exc:
             raise RuntimeError(f"failed to save chunk at {chunk.position}") from exc
 
@@ -107,3 +124,51 @@ class ChunkStore:
         self.pool.shutdown(wait=True)
         if errors:
             raise RuntimeError(f"{len(errors)} chunk saves failed") from errors[0]
+
+    def delete_chunk(self, cx: int, cz: int) -> None:
+        """Remove chunk data and update manifest/index."""
+        region = f"r.{cx//32}.{cz//32}"
+        reg_dir = self.root / region
+        path = reg_dir / f"c.{cx}.{cz}.bin"
+        if path.exists():
+            path.unlink()
+        entry = self.manifest.get(region)
+        if entry and "chunks" in entry:
+            entry["chunks"].pop(f"{cx},{cz}", None)
+            if not entry["chunks"]:
+                self.manifest.pop(region, None)
+                reg_dir = self.root / region
+                if reg_dir.exists():
+                    for f in reg_dir.glob("*"):
+                        f.unlink()
+                    reg_dir.rmdir()
+            self.manifest_path.write_text(json.dumps(self.manifest))
+        idx = reg_dir / "index.json"
+        if idx.exists():
+            try:
+                table = json.loads(idx.read_text())
+            except Exception:
+                table = {}
+            table.pop(f"{cx},{cz}", None)
+            if table:
+                idx.write_text(json.dumps(table))
+            else:
+                idx.unlink()
+
+    def compact(self) -> None:
+        """Delete stray chunk files not referenced in the manifest."""
+        for region, entry in list(self.manifest.items()):
+            reg_dir = self.root / region
+            live = set(entry.get("chunks", {}).keys())
+            if reg_dir.exists():
+                for chunk_file in reg_dir.glob("c.*.*.bin"):
+                    coords = chunk_file.stem[2:].split(".")
+                    key = f"{coords[0]},{coords[1]}"
+                    if key not in live:
+                        chunk_file.unlink()
+            if not live and reg_dir.exists():
+                for f in reg_dir.glob("*"):
+                    f.unlink()
+                reg_dir.rmdir()
+                self.manifest.pop(region)
+        self.manifest_path.write_text(json.dumps(self.manifest))

--- a/tests/test_persistence_manifest.py
+++ b/tests/test_persistence_manifest.py
@@ -1,0 +1,41 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+from src.world.persistence import ChunkStore
+
+
+@dataclass
+class Chunk:
+    position: tuple[int, int]
+    voxels: np.ndarray
+
+
+def test_manifest_and_compaction(tmp_path: Path) -> None:
+    vox = np.zeros((4, 4, 4), dtype=np.uint8)
+    chunk = Chunk(position=(0, 0), voxels=vox)
+    store = ChunkStore(root=tmp_path, codec="zstd", use_rle=True, threads=1)
+
+    store.save_chunk_sync(chunk)
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert "r.0.0" in manifest
+    reg = manifest["r.0.0"]
+    assert reg["codec"] == "zstd"
+    assert reg["chunks"]["0,0"]["offset"] == 0
+
+    idx = tmp_path / "r.0.0" / "index.json"
+    table = json.loads(idx.read_text())
+    assert "0,0" in table
+
+    stray = tmp_path / "r.0.0" / "c.99.99.bin"
+    stray.write_bytes(b"garbage")
+    store.compact()
+    assert not stray.exists()
+
+    store.delete_chunk(0, 0)
+    assert not idx.exists()
+    assert not (tmp_path / "r.0.0").exists()
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert "r.0.0" not in manifest

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,37 +88,8 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
 
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- track chunk compression and offsets via region manifest
- support deleting chunks and compacting unused region files
- add persistence test validating manifest updates and GC

## Testing
- `pytest`
- `mypy --config-file mypy.ini --explicit-package-bases src/world/persistence.py tests/test_persistence_manifest.py tests/test_player_controller_capsule.py`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d099fd0832da9be0bb90b21dbfb