### PR TITLE
Integrate VMA allocator and clean build configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,16 @@ else()
 endif()
 find_package(Threads REQUIRED)
 
+if(ENABLE_VULKAN)
+  include(FetchContent)
+  FetchContent_Declare(
+    VulkanMemoryAllocator
+    GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+    GIT_TAG v3.1.0
+  )
+  FetchContent_MakeAvailable(VulkanMemoryAllocator)
+endif()
+
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")
 if(ENABLE_VULKAN)
@@ -119,6 +129,20 @@ if(ENABLE_VULKAN)
     $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>
     $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
     $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+
+  add_executable(smoke_graphics_headless apps/smoke_graphics_headless.cpp src/vk/allocator.cpp)
+  target_include_directories(smoke_graphics_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
+  target_link_libraries(smoke_graphics_headless PRIVATE Vulkan::Vulkan VulkanMemoryAllocator Threads::Threads ${GLFW_LIB})
+  target_compile_definitions(smoke_graphics_headless PRIVATE
+    $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
+    $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>
+    $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
+    $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+
+  if(TARGET VoxelVK_Elite_ALL)
+    target_sources(VoxelVK_Elite_ALL PRIVATE src/vk/allocator.cpp)
+    target_link_libraries(VoxelVK_Elite_ALL PRIVATE VulkanMemoryAllocator)
+  endif()
 endif()
 
 # Tests
@@ -178,4 +202,3 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
-        main

--- a/apps/smoke_graphics_headless.cpp
+++ b/apps/smoke_graphics_headless.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cstring>
 #include <cstdint>
-#include <limits>
+#include "src/vk/allocator.hpp"
 #if __has_include(<GLFW/glfw3.h>)
 #include <GLFW/glfw3.h>
 #endif
@@ -15,14 +15,6 @@ static bool has_layer(const char* name){
     std::vector<VkLayerProperties> L(n); vkEnumerateInstanceLayerProperties(&n,L.data());
     for(auto& p:L){ if(std::strcmp(p.layerName,name)==0) return true; } return false;
 }
-static uint32_t find_memory_type(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags req){
-    VkPhysicalDeviceMemoryProperties mp; vkGetPhysicalDeviceMemoryProperties(phys,&mp);
-    for(uint32_t i=0;i<mp.memoryTypeCount;i++){
-        if((typeBits & (1u<<i)) && (mp.memoryTypes[i].propertyFlags & req) == req) return i;
-    }
-    return UINT32_MAX;
-}
-
 int main(){
     voxelvk::InitBuildInfoLogging();
     voxelvk::PrintBuildInfoOnce();
@@ -73,13 +65,15 @@ int main(){
     VkDevice device; if(vkCreateDevice(phys,&dci,nullptr,&device)!=VK_SUCCESS){ std::puts("vkCreateDevice failed"); return 5; }
     VkQueue q; vkGetDeviceQueue(device,qg,0,&q);
 
+    voxelvk::Allocator allocator(instance, phys, device);
+
     // Command buffer
     VkCommandPoolCreateInfo cpci{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; cpci.queueFamilyIndex=qg;
     VkCommandPool pool; vkCreateCommandPool(device,&cpci,nullptr,&pool);
     VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=pool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
     VkCommandBuffer cmd; vkAllocateCommandBuffers(device,&cbai,&cmd);
 
-    // Create 1x1 color attachment image + memory
+    // Create 1x1 color attachment image + memory via VMA
     VkImageCreateInfo ici2{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
     ici2.imageType = VK_IMAGE_TYPE_2D;
     ici2.extent = {1,1,1};
@@ -89,13 +83,8 @@ int main(){
     ici2.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     ici2.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ici2.samples = VK_SAMPLE_COUNT_1_BIT;
-    VkImage img; if(vkCreateImage(device,&ici2,nullptr,&img)!=VK_SUCCESS){ std::puts("vkCreateImage failed"); return 6; }
-    VkMemoryRequirements mr; vkGetImageMemoryRequirements(device,img,&mr);
-    uint32_t memIdx = find_memory_type(phys, mr.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    if(memIdx==UINT32_MAX){ std::puts("no mem type"); return 7; }
-    VkMemoryAllocateInfo mai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize = mr.size; mai.memoryTypeIndex = memIdx;
-    VkDeviceMemory mem; if(vkAllocateMemory(device,&mai,nullptr,&mem)!=VK_SUCCESS){ std::puts("alloc fail"); return 8; }
-    vkBindImageMemory(device,img,mem,0);
+    VkImage img; VmaAllocation alloc; VmaAllocationCreateInfo aci{}; aci.usage = VMA_MEMORY_USAGE_AUTO; aci.requiredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    if(allocator.createImage(&ici2, &aci, &img, &alloc)!=VK_SUCCESS){ std::puts("vmaCreateImage failed"); return 6; }
 
     // View
     VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
@@ -145,8 +134,7 @@ int main(){
     vkDestroyFramebuffer(device, fb, nullptr);
     vkDestroyRenderPass(device, rp, nullptr);
     vkDestroyImageView(device, view, nullptr);
-    vkFreeMemory(device, mem, nullptr);
-    vkDestroyImage(device, img, nullptr);
+    allocator.destroyImage(img, alloc);
     vkDestroyCommandPool(device, pool, nullptr);
     vkDestroyDevice(device, nullptr);
 #if defined(ENABLE_VK_DEBUG_MARKERS) || defined(ENABLE_VALIDATION_LAYERS)

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,52 +1,6 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
@@ -56,47 +10,7 @@ module.exports = [
       globals: { ...globals.node, ...globals.es2021 }
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,13 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
-      'scripts/**',
-    ],
-
-
       'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
   }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/vk/allocator.cpp
+++ b/src/vk/allocator.cpp
@@ -1,0 +1,41 @@
+#define VMA_IMPLEMENTATION
+#include "vk/allocator.hpp"
+
+namespace voxelvk {
+
+Allocator::Allocator(VkInstance instance, VkPhysicalDevice phys, VkDevice device) {
+    VmaAllocatorCreateInfo ci{};
+    ci.instance = instance;
+    ci.physicalDevice = phys;
+    ci.device = device;
+    vmaCreateAllocator(&ci, &m_allocator);
+}
+
+Allocator::~Allocator() {
+    if (m_allocator) {
+        vmaDestroyAllocator(m_allocator);
+    }
+}
+
+VkResult Allocator::createImage(const VkImageCreateInfo* imageInfo,
+                                const VmaAllocationCreateInfo* allocInfo,
+                                VkImage* image, VmaAllocation* allocation) {
+    return vmaCreateImage(m_allocator, imageInfo, allocInfo, image, allocation, nullptr);
+}
+
+void Allocator::destroyImage(VkImage image, VmaAllocation allocation) {
+    vmaDestroyImage(m_allocator, image, allocation);
+}
+
+VkResult Allocator::createBuffer(const VkBufferCreateInfo* bufferInfo,
+                                 const VmaAllocationCreateInfo* allocInfo,
+                                 VkBuffer* buffer, VmaAllocation* allocation) {
+    return vmaCreateBuffer(m_allocator, bufferInfo, allocInfo, buffer, allocation, nullptr);
+}
+
+void Allocator::destroyBuffer(VkBuffer buffer, VmaAllocation allocation) {
+    vmaDestroyBuffer(m_allocator, buffer, allocation);
+}
+
+} // namespace voxelvk
+

--- a/src/vk/allocator.hpp
+++ b/src/vk/allocator.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+
+namespace voxelvk {
+
+class Allocator {
+public:
+    Allocator(VkInstance instance, VkPhysicalDevice physicalDevice, VkDevice device);
+    ~Allocator();
+
+    Allocator(const Allocator&) = delete;
+    Allocator& operator=(const Allocator&) = delete;
+
+    VkResult createImage(const VkImageCreateInfo* imageInfo,
+                         const VmaAllocationCreateInfo* allocInfo,
+                         VkImage* image, VmaAllocation* allocation);
+    void destroyImage(VkImage image, VmaAllocation allocation);
+
+    VkResult createBuffer(const VkBufferCreateInfo* bufferInfo,
+                          const VmaAllocationCreateInfo* allocInfo,
+                          VkBuffer* buffer, VmaAllocation* allocation);
+    void destroyBuffer(VkBuffer buffer, VmaAllocation allocation);
+
+private:
+    VmaAllocator m_allocator{VK_NULL_HANDLE};
+};
+
+} // namespace voxelvk
+

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- Fetch VulkanMemoryAllocator via CMake FetchContent and build graphics smoke sample with it
- Add unified `Allocator` wrapper around VMA for Vulkan memory management
- Refactor smoke_graphics_headless sample to use VMA allocator and tidy broken lint/type configs

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d0c9690832d86edf7d35a37af16