### PR TITLE
Integrate simple frame graph for render passes

### DIFF
--- a/apps/demo_window.cpp
+++ b/apps/demo_window.cpp
@@ -3,6 +3,10 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
+#include "../src/render/frame_graph.hpp"
+#include "../src/render/voxelize_pass.hpp"
+#include "../src/render/csm_pass.hpp"
+#include "../src/render/sky_pass.hpp"
 
 int main() {
     if (!glfwInit()) return 1;
@@ -118,17 +122,18 @@ int main() {
     VkCommandPoolCreateInfo cp{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; cp.queueFamilyIndex = graphicsQueue;
     VkCommandPool pool; vkCreateCommandPool(device,&cp,nullptr,&pool);
     VkCommandBufferAllocateInfo cbai{VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=pool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=imgCount;
-    std::vector<VkCommandBuffer> cmds(imgCount); vkAllocateCommandBuffers(device,&cbai,cmds.data());
-    for(uint32_t i=0;i<imgCount;i++){
-        VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; vkBeginCommandBuffer(cmds[i],&bi);
-        VkClearValue clear; clear.color = { {0.1f, 0.2f, 0.3f, 1.0f} };
-        VkRenderPassBeginInfo rbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
-        rbi.renderPass = rp; rbi.framebuffer = fbs[i]; rbi.renderArea.extent = sci.imageExtent;
-        rbi.clearValueCount = 1; rbi.pClearValues = &clear;
-        vkCmdBeginRenderPass(cmds[i],&rbi,VK_SUBPASS_CONTENTS_INLINE);
-        vkCmdEndRenderPass(cmds[i]);
-        vkEndCommandBuffer(cmds[i]);
-    }
+    std::vector<VkCommandBuffer> cmds(imgCount);
+    vkAllocateCommandBuffers(device,&cbai,cmds.data());
+
+    // Build a simple frame graph with example passes. The passes are not fully
+    // initialized but demonstrate how to hook into the graph.
+    voxelvk::FrameGraph frameGraph;
+    voxelvk::VoxelizePass voxelPass;
+    voxelvk::CSMShadowPass csmPass;
+    voxelvk::SkyPass skyPass;
+    frameGraph.addPass(&voxelPass);
+    frameGraph.addPass(&csmPass, {voxelPass.name()});
+    frameGraph.addPass(&skyPass, {csmPass.name()});
 
     VkSemaphoreCreateInfo sci2{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
     VkSemaphore imgAvailable, renderFinished;
@@ -138,6 +143,24 @@ int main() {
     while(!glfwWindowShouldClose(window)){
         glfwPollEvents();
         uint32_t imgIndex; vkAcquireNextImageKHR(device,swapchain,UINT64_MAX,imgAvailable,VK_NULL_HANDLE,&imgIndex);
+
+        // Record commands for this frame
+        vkResetCommandBuffer(cmds[imgIndex],0);
+        VkCommandBufferBeginInfo bi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
+        vkBeginCommandBuffer(cmds[imgIndex],&bi);
+        VkClearValue clear; clear.color = { {0.1f, 0.2f, 0.3f, 1.0f} };
+        VkRenderPassBeginInfo rbi{VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO};
+        rbi.renderPass = rp; rbi.framebuffer = fbs[imgIndex];
+        rbi.renderArea.extent = sci.imageExtent;
+        rbi.clearValueCount = 1; rbi.pClearValues = &clear;
+        vkCmdBeginRenderPass(cmds[imgIndex],&rbi,VK_SUBPASS_CONTENTS_INLINE);
+
+        // Execute the frame graph which will run passes in dependency order
+        frameGraph.execute(cmds[imgIndex]);
+
+        vkCmdEndRenderPass(cmds[imgIndex]);
+        vkEndCommandBuffer(cmds[imgIndex]);
+
         VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         si.waitSemaphoreCount=1; si.pWaitSemaphores=&imgAvailable; si.pWaitDstStageMask=&waitStage;

--- a/src/render/csm_pass.hpp
+++ b/src/render/csm_pass.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <functional>
 #include <cstdint>
+#include "frame_graph.hpp"
 
 // Forward-declare VMA
 struct VmaAllocator_T;
@@ -28,7 +29,8 @@ struct CSMGpuUBO {
 // You MUST bind vertex buffers (location=0 : vec3 position) and issue draws.
 using RecordDepthDrawFn = std::function<void(VkCommandBuffer cmd, int cascadeIndex)>;
 
-struct CSMShadowPass {
+// Cascaded shadow map rendering pass.
+struct CSMShadowPass : public RenderPass {
     // resources
     VkDevice        device = VK_NULL_HANDLE;
     VmaAllocator    allocator = nullptr;
@@ -62,8 +64,17 @@ struct CSMShadowPass {
     // per-frame updates
     void updateUBO(const CSMGpuUBO& data);
 
+    // Set callback used to draw depth geometry for each cascade.
+    void setDrawCallback(const RecordDepthDrawFn& fn) { drawCallback = fn; }
+
     // record rendering: renders each cascade layer by layer with dynamic rendering
     void record(VkCommandBuffer cmd, const RecordDepthDrawFn& drawScene);
+
+    // RenderPass interface
+    const char* name() const override { return "csm"; }
+    void execute(VkCommandBuffer cmd) override {
+        if (drawCallback) record(cmd, drawCallback);
+    }
 
     // utility: get descriptor info for sampling in lighting pass
     VkImageView getDepthArrayView() const { return depthArrayView; }
@@ -78,6 +89,8 @@ private:
 
     // helpers
     uint32_t findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags);
+
+    RecordDepthDrawFn drawCallback{};
 };
 
 } // namespace voxelvk

--- a/src/render/frame_graph.cpp
+++ b/src/render/frame_graph.cpp
@@ -1,0 +1,32 @@
+#include "frame_graph.hpp"
+#include <unordered_set>
+#include <algorithm>
+
+namespace voxelvk {
+
+void FrameGraph::addPass(RenderPass* pass, std::vector<std::string> deps) {
+    nodes.push_back({pass, std::move(deps)});
+}
+
+void FrameGraph::execute(VkCommandBuffer cmd) {
+    std::unordered_set<std::string> executed;
+    std::function<void(const Node&)> run = [&](const Node& n) {
+        const std::string nm = n.pass->name();
+        if (executed.count(nm)) return;
+        for (const auto& depName : n.deps) {
+            auto it = std::find_if(nodes.begin(), nodes.end(), [&](const Node& other) {
+                return other.pass->name() == depName;
+            });
+            if (it != nodes.end()) run(*it);
+        }
+        executed.insert(nm);
+        n.pass->execute(cmd);
+    };
+
+    for (const Node& n : nodes) {
+        run(n);
+    }
+}
+
+} // namespace voxelvk
+

--- a/src/render/frame_graph.hpp
+++ b/src/render/frame_graph.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace voxelvk {
+
+// Base interface that all render passes derive from.
+class RenderPass {
+public:
+    virtual ~RenderPass() = default;
+    // Human-readable name used for dependency tracking.
+    virtual const char* name() const = 0;
+    // Execute the pass, recording commands into cmd.
+    virtual void execute(VkCommandBuffer cmd) = 0;
+};
+
+// Simple frame graph that schedules passes based on dependencies.
+class FrameGraph {
+public:
+    // Add a pass with optional dependencies specified by name.
+    void addPass(RenderPass* pass, std::vector<std::string> deps = {});
+    // Execute all registered passes in dependency order.
+    void execute(VkCommandBuffer cmd);
+
+private:
+    struct Node {
+        RenderPass* pass;
+        std::vector<std::string> deps;
+    };
+    std::vector<Node> nodes;
+};
+
+} // namespace voxelvk
+

--- a/src/render/sky_pass.hpp
+++ b/src/render/sky_pass.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <vulkan/vulkan.h>
 #include <glm/glm.hpp>
+#include "frame_graph.hpp"
 
 namespace voxelvk {
 
@@ -14,7 +15,7 @@ struct SkyPushConstants {
 };
 
 // Renders sky then overlays clouds using fullscreen shaders.
-struct SkyPass {
+struct SkyPass : public RenderPass {
     VkDevice              device = VK_NULL_HANDLE;
     VkPipeline            skyPipeline = VK_NULL_HANDLE;
     VkPipeline            cloudPipeline = VK_NULL_HANDLE;
@@ -27,6 +28,20 @@ struct SkyPass {
 
     // Record commands to draw sky then clouds (uses noiseSet for clouds).
     void record(VkCommandBuffer cmd, VkDescriptorSet noiseSet, const SkyPushConstants& pc);
+
+    // Set resources used during execution.
+    void setInputs(VkDescriptorSet noise, const SkyPushConstants& constants) {
+        noiseSet = noise; push = constants;
+    }
+
+    // RenderPass interface
+    const char* name() const override { return "sky"; }
+    void execute(VkCommandBuffer cmd) override {
+        record(cmd, noiseSet, push);
+    }
+
+    VkDescriptorSet noiseSet = VK_NULL_HANDLE;
+    SkyPushConstants push{};
 };
 
 } // namespace voxelvk

--- a/src/render/voxelize_pass.hpp
+++ b/src/render/voxelize_pass.hpp
@@ -3,6 +3,7 @@
 #include <glm/glm.hpp>
 #include <functional>
 #include <cstdint>
+#include "frame_graph.hpp"
 
 struct VmaAllocator_T;
 using VmaAllocator = VmaAllocator_T*;
@@ -13,7 +14,9 @@ namespace voxelvk {
 
 using RecordVoxelDrawFn = std::function<void(VkCommandBuffer cmd, int slice)>;
 
-struct VoxelizePass {
+// Voxelizes scene geometry into a 3D texture. Implements RenderPass so it can
+// be scheduled by the frame graph.
+struct VoxelizePass : public RenderPass {
     VkDevice      device = VK_NULL_HANDLE;
     VmaAllocator  allocator = nullptr;
     uint32_t      dim = 0;
@@ -33,7 +36,16 @@ struct VoxelizePass {
     bool init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc, uint32_t dimension);
     void destroy();
 
+    // Callback used to draw scene geometry during voxelization.
+    void setDrawCallback(const RecordVoxelDrawFn& fn) { drawCallback = fn; }
+
     void record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScene);
+
+    // RenderPass interface
+    const char* name() const override { return "voxelize"; }
+    void execute(VkCommandBuffer cmd) override {
+        if (drawCallback) record(cmd, drawCallback);
+    }
 
     VkImageView getVoxelView() const { return voxelView; }
 
@@ -42,6 +54,8 @@ private:
     bool createDescriptors();
     bool createPipeline(VkPhysicalDevice phys);
     uint32_t findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags);
+
+    RecordVoxelDrawFn drawCallback{};
 };
 
 } // namespace voxelvk


### PR DESCRIPTION
## Summary
- Introduce `FrameGraph` and `RenderPass` interface for ordering passes
- Adapt voxelization, CSM and sky passes to derive from the new interface
- Drive the frame graph from `demo_window` to execute passes in dependency order each frame

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy` *(fails: configuration error, option 'exclude' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d16e6b8832d8eb7d7711e224573