### PR TITLE
Add synchronization helper and barrier insertion for render passes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,9 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE
     src/render/csm_cpu.cpp
-    src/render/csm_pass.cpp)
+    src/render/csm_pass.cpp
+    src/render/sky_pass.cpp
+    src/render/sync_utils.cpp)
 endif()
 
 # --- Voxelization pass ---

--- a/docs/synchronization.md
+++ b/docs/synchronization.md
@@ -1,0 +1,28 @@
+# Synchronization Helpers
+
+The rendering passes now rely on a small helper located in
+`src/render/sync_utils.hpp`. It wraps common Vulkan image and buffer
+barrier code, including queue family ownership transfers.
+
+```cpp
+// Transition an image
+barrierImage(cmd, image,
+             oldLayout, newLayout,
+             srcStage, dstStage,
+             srcAccess, dstAccess,
+             aspectMask);
+```
+
+Each render pass inserts the appropriate barriers before and after
+executing its commands:
+
+- **CSMShadowPass** transitions the depth atlas to
+  `VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL` before rendering and makes
+  depth writes visible to shaders afterwards.
+- **VoxelizePass** prepares its 3D storage image for fragment shader
+  writes and later transitions it for sampling.
+- **SkyPass** transitions the target color image to a color attachment
+  layout and back to a shader–read layout when finished.
+
+Run with the Vulkan validation layers enabled to verify that the
+expected pipeline stages and access masks match the intended usage.

--- a/src/render/csm_pass.cpp
+++ b/src/render/csm_pass.cpp
@@ -1,6 +1,7 @@
 
 #include "csm_pass.hpp"
 #include "csm_descriptor.hpp"
+#include "sync_utils.hpp"
 #include <stdexcept>
 #include <cstring>
 
@@ -224,8 +225,16 @@ void CSMShadowPass::bindDepthDescriptor(VkDescriptorSet set, uint32_t binding) c
 }
 
 void CSMShadowPass::record(VkCommandBuffer cmd, const RecordDepthDrawFn& drawScene){
-    // transition to depth attachment
-    // (Assume your engine has a barrier helper; else leave to caller.)
+    // Ensure depth image is ready for attachment usage
+    barrierImage(cmd,
+                 depthImage,
+                 VK_IMAGE_LAYOUT_UNDEFINED,
+                 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                 VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
+                 0,
+                 VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+                 VK_IMAGE_ASPECT_DEPTH_BIT);
     VkViewport vp{0,0,(float)mapSize,(float)mapSize,0.0f,1.0f};
     VkRect2D sc{{0,0},{mapSize,mapSize}};
 
@@ -259,6 +268,17 @@ void CSMShadowPass::record(VkCommandBuffer cmd, const RecordDepthDrawFn& drawSce
 
         vkCmdEndRendering(cmd);
     }
+
+    // Make depth writes visible for subsequent shader reads
+    barrierImage(cmd,
+                 depthImage,
+                 VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                 VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                 VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
+                 VK_ACCESS_SHADER_READ_BIT,
+                 VK_IMAGE_ASPECT_DEPTH_BIT);
 }
 
 // --- simple file loader for SPV (engine likely has its own) ---

--- a/src/render/sky_pass.cpp
+++ b/src/render/sky_pass.cpp
@@ -1,4 +1,5 @@
 #include "sky_pass.hpp"
+#include "sync_utils.hpp"
 #include <vector>
 #include <cstdio>
 #include <cstring>
@@ -168,7 +169,18 @@ void SkyPass::destroy(){
     }
 }
 
-void SkyPass::record(VkCommandBuffer cmd, VkDescriptorSet noiseSet, const SkyPushConstants& pc){
+void SkyPass::record(VkCommandBuffer cmd, VkImage target, VkDescriptorSet noiseSet, const SkyPushConstants& pc){
+    // Transition target image for color attachment output
+    barrierImage(cmd,
+                 target,
+                 VK_IMAGE_LAYOUT_UNDEFINED,
+                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                 VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                 0,
+                 VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                 VK_IMAGE_ASPECT_COLOR_BIT);
+
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, skyPipeline);
     vkCmdPushConstants(cmd, pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(SkyPushConstants), &pc);
     vkCmdDraw(cmd, 3, 1, 0, 0);
@@ -176,6 +188,17 @@ void SkyPass::record(VkCommandBuffer cmd, VkDescriptorSet noiseSet, const SkyPus
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &noiseSet, 0, nullptr);
     vkCmdPushConstants(cmd, pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(SkyPushConstants), &pc);
     vkCmdDraw(cmd, 3, 1, 0, 0);
+
+    // Make color writes visible for subsequent shader reads
+    barrierImage(cmd,
+                 target,
+                 VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                 VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                 VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                 VK_ACCESS_SHADER_READ_BIT,
+                 VK_IMAGE_ASPECT_COLOR_BIT);
 }
 
 } // namespace voxelvk

--- a/src/render/sky_pass.hpp
+++ b/src/render/sky_pass.hpp
@@ -25,8 +25,8 @@ struct SkyPass {
     bool init(VkPhysicalDevice phys, VkDevice dev, VkFormat colorFormat);
     void destroy();
 
-    // Record commands to draw sky then clouds (uses noiseSet for clouds).
-    void record(VkCommandBuffer cmd, VkDescriptorSet noiseSet, const SkyPushConstants& pc);
+    // Record commands to draw sky then clouds to the given target image.
+    void record(VkCommandBuffer cmd, VkImage target, VkDescriptorSet noiseSet, const SkyPushConstants& pc);
 };
 
 } // namespace voxelvk

--- a/src/render/sync_utils.cpp
+++ b/src/render/sync_utils.cpp
@@ -1,0 +1,76 @@
+#include "sync_utils.hpp"
+
+namespace voxelvk {
+
+void barrierImage(
+    VkCommandBuffer cmd,
+    VkImage image,
+    VkImageLayout oldLayout,
+    VkImageLayout newLayout,
+    VkPipelineStageFlags srcStageMask,
+    VkPipelineStageFlags dstStageMask,
+    VkAccessFlags srcAccessMask,
+    VkAccessFlags dstAccessMask,
+    VkImageAspectFlags aspectMask,
+    uint32_t srcQueueFamily,
+    uint32_t dstQueueFamily,
+    uint32_t baseMipLevel,
+    uint32_t levelCount,
+    uint32_t baseArrayLayer,
+    uint32_t layerCount)
+{
+    VkImageMemoryBarrier barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccessMask;
+    barrier.dstAccessMask = dstAccessMask;
+    barrier.oldLayout = oldLayout;
+    barrier.newLayout = newLayout;
+    barrier.srcQueueFamilyIndex = srcQueueFamily;
+    barrier.dstQueueFamilyIndex = dstQueueFamily;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = aspectMask;
+    barrier.subresourceRange.baseMipLevel = baseMipLevel;
+    barrier.subresourceRange.levelCount = levelCount;
+    barrier.subresourceRange.baseArrayLayer = baseArrayLayer;
+    barrier.subresourceRange.layerCount = layerCount;
+
+    vkCmdPipelineBarrier(cmd,
+                         srcStageMask,
+                         dstStageMask,
+                         0,
+                         0, nullptr,
+                         0, nullptr,
+                         1, &barrier);
+}
+
+void barrierBuffer(
+    VkCommandBuffer cmd,
+    VkBuffer buffer,
+    VkDeviceSize offset,
+    VkDeviceSize size,
+    VkPipelineStageFlags srcStageMask,
+    VkPipelineStageFlags dstStageMask,
+    VkAccessFlags srcAccessMask,
+    VkAccessFlags dstAccessMask,
+    uint32_t srcQueueFamily,
+    uint32_t dstQueueFamily)
+{
+    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccessMask;
+    barrier.dstAccessMask = dstAccessMask;
+    barrier.srcQueueFamilyIndex = srcQueueFamily;
+    barrier.dstQueueFamilyIndex = dstQueueFamily;
+    barrier.buffer = buffer;
+    barrier.offset = offset;
+    barrier.size = size;
+
+    vkCmdPipelineBarrier(cmd,
+                         srcStageMask,
+                         dstStageMask,
+                         0,
+                         0, nullptr,
+                         1, &barrier,
+                         0, nullptr);
+}
+
+} // namespace voxelvk
+

--- a/src/render/sync_utils.hpp
+++ b/src/render/sync_utils.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <vulkan/vulkan.h>
+
+namespace voxelvk {
+
+// Helper to insert an image memory barrier with optional queue ownership transfer.
+void barrierImage(
+    VkCommandBuffer cmd,
+    VkImage image,
+    VkImageLayout oldLayout,
+    VkImageLayout newLayout,
+    VkPipelineStageFlags srcStageMask,
+    VkPipelineStageFlags dstStageMask,
+    VkAccessFlags srcAccessMask,
+    VkAccessFlags dstAccessMask,
+    VkImageAspectFlags aspectMask,
+    uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED,
+    uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED,
+    uint32_t baseMipLevel = 0,
+    uint32_t levelCount = VK_REMAINING_MIP_LEVELS,
+    uint32_t baseArrayLayer = 0,
+    uint32_t layerCount = VK_REMAINING_ARRAY_LAYERS);
+
+// Helper to insert a buffer memory barrier with optional queue ownership transfer.
+void barrierBuffer(
+    VkCommandBuffer cmd,
+    VkBuffer buffer,
+    VkDeviceSize offset,
+    VkDeviceSize size,
+    VkPipelineStageFlags srcStageMask,
+    VkPipelineStageFlags dstStageMask,
+    VkAccessFlags srcAccessMask,
+    VkAccessFlags dstAccessMask,
+    uint32_t srcQueueFamily = VK_QUEUE_FAMILY_IGNORED,
+    uint32_t dstQueueFamily = VK_QUEUE_FAMILY_IGNORED);
+
+} // namespace voxelvk
+

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -1,4 +1,5 @@
 #include "voxelize_pass.hpp"
+#include "sync_utils.hpp"
 #include <stdexcept>
 #include <vector>
 #include <cstdio>
@@ -215,6 +216,17 @@ bool VoxelizePass::createPipeline(VkPhysicalDevice phys){
 }
 
 void VoxelizePass::record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScene){
+    // Prepare storage image for writes
+    barrierImage(cmd,
+                 voxelImage,
+                 VK_IMAGE_LAYOUT_UNDEFINED,
+                 VK_IMAGE_LAYOUT_GENERAL,
+                 VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                 0,
+                 VK_ACCESS_SHADER_WRITE_BIT,
+                 VK_IMAGE_ASPECT_COLOR_BIT);
+
     VkViewport vp{0,0,(float)dim,(float)dim,0.0f,1.0f};
     VkRect2D sc{{0,0},{dim,dim}};
 
@@ -244,6 +256,17 @@ void VoxelizePass::record(VkCommandBuffer cmd, const RecordVoxelDrawFn& drawScen
         drawScene(cmd, (int)z);
         vkCmdEndRendering(cmd);
     }
+
+    // Make voxel image writes available for sampling
+    barrierImage(cmd,
+                 voxelImage,
+                 VK_IMAGE_LAYOUT_GENERAL,
+                 VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                 VK_ACCESS_SHADER_WRITE_BIT,
+                 VK_ACCESS_SHADER_READ_BIT,
+                 VK_IMAGE_ASPECT_COLOR_BIT);
 }
 
 static std::vector<char> readFile(const char* path){

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add sync_utils helper for common buffer and image barriers
- apply explicit barriers around CSM, voxelization, and sky passes
- document synchronization patterns and validation usage

## Testing
- `pytest`
- `mypy .` *(fails: option 'exclude' in section 'mypy' already exists)*
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.')*


------
https://chatgpt.com/codex/tasks/task_e_68a42d18a784832db3033d5482b15ce4