### PR TITLE
Add compression deps and manifest for ChunkStore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# External dependencies
+include(cmake/Dependencies.cmake)
+
 option(ENABLE_VALIDATION_LAYERS "Enable Vulkan validation layers" ON)
 option(ENABLE_VK_DEBUG_MARKERS  "Enable VK_EXT_debug_utils markers" ON)
 option(ENABLE_IMGUI_OVERLAY     "Enable ImGui debug HUD overlay" ON)
@@ -68,6 +71,22 @@ else()
   endif()
 endif()
 find_package(Threads REQUIRED)
+
+# Chunk persistence library
+add_library(world_persistence src/world/persistence.cpp)
+target_include_directories(world_persistence PUBLIC ${CMAKE_SOURCE_DIR}/src)
+
+set(ZSTD_TARGET zstd)
+if(TARGET libzstd_static)
+  set(ZSTD_TARGET libzstd_static)
+endif()
+
+set(LZ4_TARGET lz4)
+if(TARGET lz4_static)
+  set(LZ4_TARGET lz4_static)
+endif()
+
+target_link_libraries(world_persistence PUBLIC ${ZSTD_TARGET} ${LZ4_TARGET} Threads::Threads)
 
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")
@@ -178,4 +197,4 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
-        main
+        

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,0 +1,25 @@
+include(FetchContent)
+
+# Fetch zstd
+if(NOT TARGET zstd)
+  FetchContent_Declare(
+    zstd
+    GIT_REPOSITORY https://github.com/facebook/zstd.git
+    GIT_TAG v1.5.5
+  )
+  set(ZSTD_BUILD_PROGRAMS OFF CACHE INTERNAL "")
+  set(ZSTD_BUILD_TESTS OFF CACHE INTERNAL "")
+  FetchContent_MakeAvailable(zstd)
+endif()
+
+# Fetch lz4
+if(NOT TARGET lz4)
+  FetchContent_Declare(
+    lz4
+    GIT_REPOSITORY https://github.com/lz4/lz4.git
+    GIT_TAG v1.9.4
+  )
+  set(LZ4_BUILD_CLI OFF CACHE INTERNAL "")
+  set(LZ4_BUILD_TESTS OFF CACHE INTERNAL "")
+  FetchContent_MakeAvailable(lz4)
+endif()

--- a/src/world/persistence.cpp
+++ b/src/world/persistence.cpp
@@ -5,6 +5,8 @@
 #include <iterator>
 #include <algorithm>
 #include <iostream>
+#include <unordered_map>
+#include <sstream>
 
 #if __has_include(<zstd.h>)
 #define VOXELVK_HAS_ZSTD 1
@@ -33,6 +35,54 @@ std::filesystem::path ChunkStore::_region_dir(int cx, int cz) const {
     std::filesystem::path d = root_ / ("r." + std::to_string(cx / 32) + "." + std::to_string(cz / 32));
     std::filesystem::create_directories(d);
     return d;
+}
+
+std::filesystem::path ChunkStore::_manifest_path(int cx, int cz) const {
+    return _region_dir(cx, cz) / "region_manifest.json";
+}
+
+static std::unordered_map<std::string, std::size_t>
+_load_manifest(const std::filesystem::path &p) {
+    std::unordered_map<std::string, std::size_t> table;
+    if (!std::filesystem::exists(p)) return table;
+    std::ifstream ifs(p);
+    if (!ifs) return table;
+    std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    std::size_t pos = 0;
+    while ((pos = content.find('"', pos)) != std::string::npos) {
+        std::size_t end = content.find('"', pos + 1);
+        if (end == std::string::npos) break;
+        std::string key = content.substr(pos + 1, end - pos - 1);
+        std::size_t size_pos = content.find("\"size\"", end);
+        if (size_pos == std::string::npos) break;
+        size_pos = content.find(':', size_pos);
+        if (size_pos == std::string::npos) break;
+        std::size_t comma = content.find_first_of(",}", size_pos);
+        std::size_t value = static_cast<std::size_t>(std::stoll(content.substr(size_pos + 1, comma - size_pos - 1)));
+        table[key] = value;
+        pos = comma;
+    }
+    return table;
+}
+
+static void _write_manifest(const std::filesystem::path &p,
+                            const std::unordered_map<std::string, std::size_t> &table) {
+    std::ofstream ofs(p, std::ios::binary);
+    ofs << '{';
+    bool first = true;
+    for (const auto &kv : table) {
+        if (!first) ofs << ',';
+        ofs << '"' << kv.first << "\": {\"size\": " << kv.second << '}';
+        first = false;
+    }
+    ofs << '}';
+}
+
+void ChunkStore::_update_manifest(int cx, int cz, std::size_t size) {
+    auto path = _manifest_path(cx, cz);
+    auto table = _load_manifest(path);
+    table[std::to_string(cx) + "," + std::to_string(cz)] = size;
+    _write_manifest(path, table);
 }
 
 std::filesystem::path ChunkStore::chunk_path(int cx, int cz) const {
@@ -86,9 +136,11 @@ std::vector<std::uint8_t> ChunkStore::_compress(const std::vector<std::uint8_t> 
     }
 #if VOXELVK_HAS_LZ4
     if (codec_ == "lz4") {
-        size_t max_size = LZ4F_compressFrameBound(data.size(), nullptr);
+        LZ4F_preferences_t prefs{};
+        prefs.frameInfo.contentSize = data.size();
+        size_t max_size = LZ4F_compressFrameBound(data.size(), &prefs);
         std::vector<std::uint8_t> out(max_size);
-        size_t csize = LZ4F_compressFrame(out.data(), max_size, data.data(), data.size(), nullptr);
+        size_t csize = LZ4F_compressFrame(out.data(), max_size, data.data(), data.size(), &prefs);
         if (LZ4F_isError(csize)) {
             throw std::runtime_error("lz4 compress failed");
         }
@@ -123,17 +175,22 @@ std::vector<std::uint8_t> ChunkStore::_decompress(const std::vector<std::uint8_t
         LZ4F_getFrameInfo(dctx, &info, src, &consumed);
         src += consumed;
         src_size -= consumed;
-        if (info.contentSize == 0) {
-            LZ4F_freeDecompressionContext(dctx);
-            throw std::runtime_error("lz4 unknown content size");
+        std::vector<std::uint8_t> out;
+        out.resize(info.contentSize ? info.contentSize : data.size() * 4);
+        size_t pos = 0;
+        while (true) {
+            size_t dst_size = out.size() - pos;
+            size_t ret = LZ4F_decompress(dctx, out.data() + pos, &dst_size, src, &src_size, nullptr);
+            if (LZ4F_isError(ret)) {
+                LZ4F_freeDecompressionContext(dctx);
+                throw std::runtime_error("lz4 decompress failed");
+            }
+            pos += dst_size;
+            if (ret == 0) break;
+            if (pos == out.size()) out.resize(out.size() * 2);
         }
-        std::vector<std::uint8_t> out(info.contentSize);
-        size_t dst_size = out.size();
-        size_t result = LZ4F_decompress(dctx, out.data(), &dst_size, src, &src_size, nullptr);
         LZ4F_freeDecompressionContext(dctx);
-        if (LZ4F_isError(result)) {
-            throw std::runtime_error("lz4 decompress failed");
-        }
+        out.resize(pos);
         return out;
     }
 #endif
@@ -171,11 +228,7 @@ void ChunkStore::save_chunk_sync(const Chunk &chunk) {
     std::ofstream ofs(path, std::ios::binary);
     ofs.write(reinterpret_cast<const char *>(blob.data()), static_cast<std::streamsize>(blob.size()));
     ofs.close();
-
-    // Minimal index.json write
-    auto idx = _region_dir(cx, cz) / "index.json";
-    std::ofstream idxf(idx, std::ios::binary);
-    idxf << "{\"" << cx << "," << cz << "\": {\"saved\": true}}";
+    _update_manifest(cx, cz, blob.size());
 }
 
 void ChunkStore::save_async(const Chunk &chunk) {
@@ -220,6 +273,29 @@ void ChunkStore::wait_all() {
         }
     }
     futures_.clear();
+}
+
+void ChunkStore::compact_region(int rx, int rz) {
+    auto dir = root_ / ("r." + std::to_string(rx) + "." + std::to_string(rz));
+    auto manifest = dir / "region_manifest.json";
+    auto table = _load_manifest(manifest);
+    bool changed = false;
+    for (auto it = table.begin(); it != table.end();) {
+        auto key = it->first;
+        auto pos = key.find(',');
+        int cx = std::stoi(key.substr(0, pos));
+        int cz = std::stoi(key.substr(pos + 1));
+        auto chunk_file = dir / ("c." + std::to_string(cx) + "." + std::to_string(cz) + ".bin");
+        if (!std::filesystem::exists(chunk_file)) {
+            it = table.erase(it);
+            changed = true;
+        } else {
+            ++it;
+        }
+    }
+    if (changed) {
+        _write_manifest(manifest, table);
+    }
 }
 
 } // namespace world

--- a/src/world/persistence.hpp
+++ b/src/world/persistence.hpp
@@ -37,9 +37,12 @@ public:
     void save_async(const Chunk &chunk);
     std::optional<ChunkData> load_chunk(int cx, int cz);
     void wait_all();
+    void compact_region(int rx, int rz);
 
 private:
     std::filesystem::path _region_dir(int cx, int cz) const;
+    std::filesystem::path _manifest_path(int cx, int cz) const;
+    void _update_manifest(int cx, int cz, std::size_t size);
     std::vector<std::uint8_t> _compress(const std::vector<std::uint8_t> &data) const;
     std::vector<std::uint8_t> _decompress(const std::vector<std::uint8_t> &data) const;
 

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -28,6 +28,7 @@ class ChunkStore:
     def _region_dir(self, cx, cz):
         d = self.root / f"r.{cx//32}.{cz//32}"; d.mkdir(exist_ok=True); return d
     def chunk_path(self, cx, cz): return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
+    def _manifest_path(self, cx, cz): return self._region_dir(cx, cz) / "region_manifest.json"
 
     def _compress(self, b: bytes) -> bytes:
         if self.codec=="zstd" and has_zstd:
@@ -57,15 +58,15 @@ class ChunkStore:
                 data = header + vox.tobytes()
             blob = self._compress(data)
             self.chunk_path(cx, cz).write_bytes(blob)
-            idx = self._region_dir(cx, cz) / "index.json"
+            manifest = self._manifest_path(cx, cz)
             table = {}
-            if idx.exists():
+            if manifest.exists():
                 try:
-                    table = json.loads(idx.read_text())
+                    table = json.loads(manifest.read_text())
                 except Exception:
                     table = {}
-            table[f"{cx},{cz}"] = {"saved": True}
-            idx.write_text(json.dumps(table))
+            table[f"{cx},{cz}"] = {"size": len(blob), "codec": self.codec, "rle": self.use_rle}
+            manifest.write_text(json.dumps(table))
         except Exception as exc:
             raise RuntimeError(f"failed to save chunk at {chunk.position}") from exc
 
@@ -107,3 +108,21 @@ class ChunkStore:
         self.pool.shutdown(wait=True)
         if errors:
             raise RuntimeError(f"{len(errors)} chunk saves failed") from errors[0]
+
+    def compact_region(self, rx: int, rz: int) -> None:
+        d = self.root / f"r.{rx}.{rz}"
+        manifest = d / "region_manifest.json"
+        if not manifest.exists():
+            return
+        try:
+            table = json.loads(manifest.read_text())
+        except Exception:
+            return
+        changed = False
+        for key in list(table.keys()):
+            cx, cz = map(int, key.split(","))
+            if not (d / f"c.{cx}.{cz}.bin").exists():
+                del table[key]
+                changed = True
+        if changed:
+            manifest.write_text(json.dumps(table))

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -1,42 +1,86 @@
-
 # mypy: ignore-errors
 
+import json
+import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-import numpy as np
+import pytest
+
+np = pytest.importorskip("numpy")
 
 from src.world.persistence import ChunkStore as PyChunkStore
 
 
-def _compile_loader(tmp_path: Path, repo_root: Path) -> Path:
-    code = r"""
-#include "src/world/persistence.hpp"
+def _compile_loader(tmp_path: Path, repo_root: Path, codec: str) -> Path:
+    code = f"""
+#include \"src/world/persistence.hpp\"
 #include <iostream>
 using namespace world;
-int main(int argc, char** argv){
+int main(int argc, char** argv){{
     std::string root = argv[1];
-    ChunkStore store(root, "zstd", true);
+    ChunkStore store(root, \"{codec}\", true);
     auto chunk = store.load_chunk(0,0);
     if(!chunk) return 1;
     std::cout.write(reinterpret_cast<const char*>(chunk->voxels.data()), chunk->voxels.size());
     return 0;
-}
+}}
 """
     src_file = tmp_path / "loader.cpp"
     src_file.write_text(code)
-    exe = tmp_path / "loader"
+    exe = tmp_path / f"loader_{codec}"
     subprocess.check_call([
         "g++", "-std=c++20", str(src_file), str(repo_root / "src/world/persistence.cpp"),
-        "-I", str(repo_root), "-lzstd", "-pthread", "-o", str(exe)
+        "-I", str(repo_root), "-lzstd", "-llz4", "-pthread", "-o", str(exe)
     ], cwd=repo_root)
     return exe
 
 
-def test_cpp_chunk_store_roundtrip(tmp_path: Path) -> None:
+def _compile_compactor(tmp_path: Path, repo_root: Path, codec: str) -> Path:
+    code = f"""
+#include \"src/world/persistence.hpp\"
+using namespace world;
+int main(int argc, char** argv){{
+    std::string root = argv[1];
+    ChunkStore store(root, \"{codec}\", true);
+    store.compact_region(0,0);
+    return 0;
+}}
+"""
+    src_file = tmp_path / "compactor.cpp"
+    src_file.write_text(code)
+    exe = tmp_path / f"compactor_{codec}"
+    subprocess.check_call([
+        "g++", "-std=c++20", str(src_file), str(repo_root / "src/world/persistence.cpp"),
+        "-I", str(repo_root), "-lzstd", "-llz4", "-pthread", "-o", str(exe)
+    ], cwd=repo_root)
+    return exe
+
+
+@pytest.mark.parametrize("codec", ["zstd", "lz4"])
+def test_cpp_chunk_store_roundtrip(tmp_path: Path, codec: str) -> None:
     repo_root = Path(__file__).resolve().parent.parent
     vox = np.arange(64, dtype=np.uint8).reshape((4, 4, 4))
+
+    @dataclass
+    class Chunk:
+        position: tuple[int, int]
+        voxels: np.ndarray
+
+    chunk = Chunk(position=(0, 0), voxels=vox)
+
+    store = PyChunkStore(root=tmp_path, codec=codec, use_rle=True, threads=1)
+    store.save_chunk_sync(chunk)
+
+    loader = _compile_loader(tmp_path, repo_root, codec)
+    output = subprocess.check_output([str(loader), str(tmp_path)], cwd=repo_root)
+    assert output == vox.tobytes()
+
+
+def test_region_manifest_compaction(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    vox = np.zeros((4, 4, 4), dtype=np.uint8)
 
     @dataclass
     class Chunk:
@@ -48,13 +92,14 @@ def test_cpp_chunk_store_roundtrip(tmp_path: Path) -> None:
     store = PyChunkStore(root=tmp_path, codec="zstd", use_rle=True, threads=1)
     store.save_chunk_sync(chunk)
 
-    loader = _compile_loader(tmp_path, repo_root)
-    output = subprocess.check_output([str(loader), str(tmp_path)], cwd=repo_root)
-    assert output == vox.tobytes()
+    manifest = tmp_path / "r.0.0" / "region_manifest.json"
+    table = json.loads(manifest.read_text())
+    assert "0,0" in table
 
-import pytest
-np = pytest.importorskip("numpy")
-pytest.skip(
-    "chunk store roundtrip requires building C++ components; skipped in CI",
-    allow_module_level=True,
-)
+    # remove chunk file then compact via C++ helper
+    (tmp_path / "r.0.0" / "c.0.0.bin").unlink()
+    compactor = _compile_compactor(tmp_path, repo_root, "zstd")
+    subprocess.check_call([str(compactor), str(tmp_path)], cwd=repo_root)
+
+    table = json.loads(manifest.read_text())
+    assert "0,0" not in table


### PR DESCRIPTION
## Summary
- add zstd and lz4 via FetchContent and expose `world_persistence` library
- track chunk metadata in region_manifest.json with compaction support
- test zstd/lz4 roundtrip and manifest cleanup

## Testing
- `mypy --config-file=/tmp/mypy_empty.ini --ignore-missing-imports --explicit-package-bases src/world/persistence.py tests/test_chunk_store_cpp.py`
- `npx eslint .` *(fails: Unexpected token '.' in eslint.config.cjs)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `pytest tests/test_chunk_store_cpp.py`


------
https://chatgpt.com/codex/tasks/task_e_68a42d22931c832da1a73eb0e6ad4eb6