### PR TITLE
Integrate Vulkan Memory Allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,9 @@ else()
 endif()
 find_package(Threads REQUIRED)
 
+# External dependencies
+include(cmake/Dependencies.cmake)
+
 # Shader pipeline (glslc preferred; fallback glslangValidator)
 set(SPV_OUT "")
 if(ENABLE_VULKAN)
@@ -111,9 +114,10 @@ endif()
 
 if(ENABLE_VULKAN)
   add_executable(smoke_headless apps/smoke_headless.cpp)
+  target_sources(smoke_headless PRIVATE src/vk/vma_allocator.cpp)
   add_dependencies(smoke_headless VoxelVK_Shaders)
   target_include_directories(smoke_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB})
+  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB} VMA)
   target_compile_definitions(smoke_headless PRIVATE
     $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
     $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,0 +1,12 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  VulkanMemoryAllocator
+  GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+  GIT_TAG v3.1.0
+)
+
+FetchContent_MakeAvailable(VulkanMemoryAllocator)
+
+add_library(VMA INTERFACE)
+target_include_directories(VMA INTERFACE ${vulkanmemoryallocator_SOURCE_DIR}/include)

--- a/src/render/csm_pass.cpp
+++ b/src/render/csm_pass.cpp
@@ -4,8 +4,7 @@
 #include <stdexcept>
 #include <cstring>
 
-// Expect VMA headers available
-#include "vk_mem_alloc.h"
+#include "vk/vma_allocator.hpp"
 
 namespace voxelvk {
 

--- a/src/render/ibl_brdf.cpp
+++ b/src/render/ibl_brdf.cpp
@@ -4,6 +4,8 @@
 #include <cassert>
 #include <cstring>
 
+#include "vk/vma_allocator.hpp"
+
 namespace voxelvk {
 
 static uint32_t FindMemoryType(VkPhysicalDevice phys, uint32_t typeFilter, VkMemoryPropertyFlags properties) {

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cstdio>
 
-#include "vk_mem_alloc.h"
+#include "vk/vma_allocator.hpp"
 
 namespace voxelvk {
 

--- a/src/vk/vma_allocator.cpp
+++ b/src/vk/vma_allocator.cpp
@@ -1,0 +1,28 @@
+#define VMA_IMPLEMENTATION
+#include "vma_allocator.hpp"
+
+namespace voxelvk {
+
+VmaAllocator create_vma_allocator(VkInstance instance,
+                                 VkPhysicalDevice physical_device,
+                                 VkDevice device) {
+    VmaAllocatorCreateInfo info{};
+    info.instance = instance;
+    info.physicalDevice = physical_device;
+    info.device = device;
+
+    VmaAllocator allocator = nullptr;
+    if (vmaCreateAllocator(&info, &allocator) != VK_SUCCESS) {
+        return nullptr;
+    }
+    return allocator;
+}
+
+void destroy_vma_allocator(VmaAllocator allocator) {
+    if (allocator) {
+        vmaDestroyAllocator(allocator);
+    }
+}
+
+} // namespace voxelvk
+

--- a/src/vk/vma_allocator.hpp
+++ b/src/vk/vma_allocator.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+
+namespace voxelvk {
+
+// Create a VMA allocator bound to the given Vulkan instance, physical device, and device.
+VmaAllocator create_vma_allocator(VkInstance instance,
+                                 VkPhysicalDevice physical_device,
+                                 VkDevice device);
+
+// Destroy a previously created allocator.
+void destroy_vma_allocator(VmaAllocator allocator);
+
+} // namespace voxelvk
+


### PR DESCRIPTION
## Summary
- fetch and expose Vulkan Memory Allocator via new cmake dependency
- wrap allocator creation/destruction helpers
- use VMA headers across render modules

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py:114)*
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.' in eslint.config.cjs:35)*
- `mypy` *(fails: option 'exclude' already exists in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a42d246970832dac8a9a912ac2ad87