### PR TITLE
feat(render): add VMA allocator helpers

### DIFF
--- a/docs/memory_allocators.md
+++ b/docs/memory_allocators.md
@@ -1,0 +1,41 @@
+# Memory Allocation Helpers
+
+The render subsystem exposes a small set of helpers built on top of
+[Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator)
+(VMA). These utilities centralise common allocation patterns and help
+avoid fragmentation by funnelling allocations through shared helpers.
+
+## Staging Buffers
+
+```cpp
+voxelvk::StagingBuffer buf;
+createStagingBuffer(allocator, size, buf);
+// write to buf.mapped then issue copies
+vkCmdCopyBuffer(cmd, buf.buffer, gpuBuffer, 1, &copy);
+```
+
+Staging buffers are host visible and persistently mapped. Call
+`destroyStagingBuffer` when finished.
+
+## Upload and Readback
+
+`uploadBuffer` and `readbackBuffer` provide one-shot utilities for
+copying data between the host and device using a temporary staging
+buffer.
+
+## Transient Pool
+
+`TransientBufferPool` lets render passes allocate scratch buffers that
+are freed each frame:
+
+```cpp
+TransientBufferPool pool;
+pool.init(allocator);
+// each frame
+pool.reset();
+VkBuffer tmp; VmaAllocation alloc;
+pool.allocate(size, usage, tmp, alloc);
+```
+
+Resetting the pool releases all tracked buffers, simplifying cleanup and
+reducing fragmentation.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,15 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -107,127 +20,12 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
       '**/build/**',
     ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
     rules: {
       'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
+      'semi': ['error', 'always'],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
 exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/src/render/allocators.cpp
+++ b/src/render/allocators.cpp
@@ -1,0 +1,107 @@
+#include "allocators.hpp"
+#include <cstring>
+
+namespace voxelvk {
+
+bool createStagingBuffer(VmaAllocator allocator, VkDeviceSize size, StagingBuffer& out){
+    VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bi.size = size;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO;
+    aci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VmaAllocationInfo info{};
+    if(vmaCreateBuffer(allocator, &bi, &aci, &out.buffer, &out.allocation, &info) != VK_SUCCESS)
+        return false;
+    out.mapped = info.pMappedData;
+    return true;
+}
+
+void destroyStagingBuffer(VmaAllocator allocator, StagingBuffer& buf){
+    if(buf.buffer != VK_NULL_HANDLE){
+        vmaDestroyBuffer(allocator, buf.buffer, buf.allocation);
+        buf.buffer = VK_NULL_HANDLE;
+        buf.allocation = nullptr;
+        buf.mapped = nullptr;
+    }
+}
+
+bool uploadBuffer(VmaAllocator allocator, VkCommandBuffer cmd, VkBuffer dst, const void* data, VkDeviceSize size){
+    StagingBuffer staging{};
+    if(!createStagingBuffer(allocator, size, staging)) return false;
+    std::memcpy(staging.mapped, data, static_cast<size_t>(size));
+    VkBufferCopy copy{0,0,size};
+    vkCmdCopyBuffer(cmd, staging.buffer, dst, 1, &copy);
+    destroyStagingBuffer(allocator, staging);
+    return true;
+}
+
+bool readbackBuffer(VmaAllocator allocator, VkCommandBuffer cmd, VkBuffer src, void* dst, VkDeviceSize size){
+    StagingBuffer staging{};
+    if(!createStagingBuffer(allocator, size, staging)) return false;
+    VkBufferCopy copy{0,0,size};
+    vkCmdCopyBuffer(cmd, src, staging.buffer, 1, &copy);
+    std::memcpy(dst, staging.mapped, static_cast<size_t>(size));
+    destroyStagingBuffer(allocator, staging);
+    return true;
+}
+
+bool allocateImage(VmaAllocator allocator, const VkImageCreateInfo& ci, VkImage& image, VmaAllocation& alloc){
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    return vmaCreateImage(allocator, &ci, &aci, &image, &alloc, nullptr) == VK_SUCCESS;
+}
+
+bool allocateDeviceBuffer(VmaAllocator allocator, VkDeviceSize size, VkBufferUsageFlags usage, VkBuffer& buffer, VmaAllocation& alloc){
+    VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bi.size = size;
+    bi.usage = usage;
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+    return vmaCreateBuffer(allocator, &bi, &aci, &buffer, &alloc, nullptr) == VK_SUCCESS;
+}
+
+void destroyImage(VmaAllocator allocator, VkImage& image, VmaAllocation& alloc){
+    if(image != VK_NULL_HANDLE){
+        vmaDestroyImage(allocator, image, alloc);
+        image = VK_NULL_HANDLE;
+        alloc = nullptr;
+    }
+}
+
+void destroyBuffer(VmaAllocator allocator, VkBuffer& buffer, VmaAllocation& alloc){
+    if(buffer != VK_NULL_HANDLE){
+        vmaDestroyBuffer(allocator, buffer, alloc);
+        buffer = VK_NULL_HANDLE;
+        alloc = nullptr;
+    }
+}
+
+void TransientBufferPool::init(VmaAllocator a){
+    allocator = a;
+}
+
+void TransientBufferPool::reset(){
+    for(auto& b : buffers){
+        vmaDestroyBuffer(allocator, b.first, b.second);
+    }
+    buffers.clear();
+}
+
+void TransientBufferPool::destroy(){
+    reset();
+    allocator = nullptr;
+}
+
+bool TransientBufferPool::allocate(VkDeviceSize size, VkBufferUsageFlags usage, VkBuffer& buffer, VmaAllocation& allocation){
+    if(!allocateDeviceBuffer(allocator, size, usage, buffer, allocation))
+        return false;
+    buffers.emplace_back(buffer, allocation);
+    return true;
+}
+
+} // namespace voxelvk
+

--- a/src/render/allocators.hpp
+++ b/src/render/allocators.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include "vk_mem_alloc.h"
+#include <vector>
+
+namespace voxelvk {
+
+struct StagingBuffer {
+    VkBuffer buffer{VK_NULL_HANDLE};
+    VmaAllocation allocation{nullptr};
+    void* mapped{nullptr};
+};
+
+bool createStagingBuffer(VmaAllocator allocator, VkDeviceSize size, StagingBuffer& out);
+void destroyStagingBuffer(VmaAllocator allocator, StagingBuffer& buf);
+
+bool uploadBuffer(VmaAllocator allocator, VkCommandBuffer cmd, VkBuffer dst, const void* data, VkDeviceSize size);
+bool readbackBuffer(VmaAllocator allocator, VkCommandBuffer cmd, VkBuffer src, void* dst, VkDeviceSize size);
+
+bool allocateImage(VmaAllocator allocator, const VkImageCreateInfo& ci, VkImage& image, VmaAllocation& alloc);
+bool allocateDeviceBuffer(VmaAllocator allocator, VkDeviceSize size, VkBufferUsageFlags usage, VkBuffer& buffer, VmaAllocation& alloc);
+void destroyImage(VmaAllocator allocator, VkImage& image, VmaAllocation& alloc);
+void destroyBuffer(VmaAllocator allocator, VkBuffer& buffer, VmaAllocation& alloc);
+
+class TransientBufferPool {
+public:
+    void init(VmaAllocator allocator);
+    void reset();
+    void destroy();
+    bool allocate(VkDeviceSize size, VkBufferUsageFlags usage, VkBuffer& buffer, VmaAllocation& allocation);
+private:
+    VmaAllocator allocator{nullptr};
+    std::vector<std::pair<VkBuffer, VmaAllocation>> buffers;
+};
+
+} // namespace voxelvk
+

--- a/src/render/csm_pass.cpp
+++ b/src/render/csm_pass.cpp
@@ -4,8 +4,7 @@
 #include <stdexcept>
 #include <cstring>
 
-// Expect VMA headers available
-#include "vk_mem_alloc.h"
+#include "allocators.hpp"
 
 namespace voxelvk {
 
@@ -37,7 +36,7 @@ void CSMShadowPass::destroy(){
     if(uboSet) {} // freed with pool
     if(descPool) vkDestroyDescriptorPool(device, descPool, nullptr);
     if(uboSetLayout) vkDestroyDescriptorSetLayout(device, uboSetLayout, nullptr);
-    if(ubo){ vmaDestroyBuffer(allocator, ubo, uboAlloc); ubo=nullptr; }
+    destroyStagingBuffer(allocator, ubo);
     if(depthSampler) vkDestroySampler(device, depthSampler, nullptr);
     for(auto v: layerViews) vkDestroyImageView(device, v, nullptr);
     if(depthArrayView) vkDestroyImageView(device, depthArrayView, nullptr);
@@ -55,9 +54,7 @@ bool CSMShadowPass::createDepthArray(VkPhysicalDevice phys){
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VmaAllocationCreateInfo aci{};
-    aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-    if(vmaCreateImage(allocator, &ci, &aci, &depthImage, &depthAlloc, nullptr) != VK_SUCCESS)
+    if(!allocateImage(allocator, ci, depthImage, depthAlloc))
         return false;
 
     // Array view for sampling in lighting pass
@@ -94,14 +91,7 @@ bool CSMShadowPass::createSampler(){
 }
 
 bool CSMShadowPass::createUBO(){
-    VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
-    bi.size = sizeof(CSMGpuUBO);
-    bi.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    VmaAllocationCreateInfo aci{};
-    aci.usage = VMA_MEMORY_USAGE_AUTO;
-    aci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
-                VMA_ALLOCATION_CREATE_MAPPED_BIT;
-    if(vmaCreateBuffer(allocator, &bi, &aci, &ubo, &uboAlloc, nullptr) != VK_SUCCESS)
+    if(!createStagingBuffer(allocator, sizeof(CSMGpuUBO), ubo))
         return false;
 
     // descriptor
@@ -123,7 +113,7 @@ bool CSMShadowPass::createUBO(){
     ai.descriptorPool = descPool; ai.descriptorSetCount = 1; ai.pSetLayouts = &uboSetLayout;
     if(vkAllocateDescriptorSets(device, &ai, &uboSet) != VK_SUCCESS) return false;
 
-    VkDescriptorBufferInfo dbi{ubo, 0, sizeof(CSMGpuUBO)};
+    VkDescriptorBufferInfo dbi{ubo.buffer, 0, sizeof(CSMGpuUBO)};
     VkWriteDescriptorSet w{VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET};
     w.dstSet = uboSet; w.dstBinding = 3; w.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     w.descriptorCount = 1; w.pBufferInfo = &dbi;
@@ -212,11 +202,7 @@ bool CSMShadowPass::createPipeline(VkPhysicalDevice /*phys*/){
 }
 
 void CSMShadowPass::updateUBO(const CSMGpuUBO& data){
-    // host-visible vma buffer
-    void* p = nullptr;
-    vmaMapMemory(allocator, uboAlloc, &p);
-    std::memcpy(p, &data, sizeof(data));
-    vmaUnmapMemory(allocator, uboAlloc);
+    std::memcpy(ubo.mapped, &data, sizeof(data));
 }
 
 void CSMShadowPass::bindDepthDescriptor(VkDescriptorSet set, uint32_t binding) const{

--- a/src/render/csm_pass.hpp
+++ b/src/render/csm_pass.hpp
@@ -6,6 +6,8 @@
 #include <functional>
 #include <cstdint>
 
+#include "allocators.hpp"
+
 // Forward-declare VMA
 struct VmaAllocator_T;
 using VmaAllocator = VmaAllocator_T*;
@@ -51,8 +53,7 @@ struct CSMShadowPass {
     VkDescriptorSet         uboSet = VK_NULL_HANDLE;
 
     // UBO
-    VkBuffer        ubo = VK_NULL_HANDLE;
-    VmaAllocation   uboAlloc = nullptr;
+    StagingBuffer   ubo{};
 
     // init / destroy
     bool init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc,

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 #include <cstdio>
 
-#include "vk_mem_alloc.h"
+#include "allocators.hpp"
 
 namespace voxelvk {
 
@@ -45,7 +45,7 @@ void VoxelizePass::destroy(){
     if(descPool) vkDestroyDescriptorPool(device, descPool, nullptr);
     if(setLayout) vkDestroyDescriptorSetLayout(device, setLayout, nullptr);
     if(voxelView) vkDestroyImageView(device, voxelView, nullptr);
-    if(voxelImage) vmaDestroyImage(allocator, voxelImage, voxelAlloc);
+    destroyImage(allocator, voxelImage, voxelAlloc);
 }
 
 bool VoxelizePass::createImage(VkPhysicalDevice phys){
@@ -59,9 +59,7 @@ bool VoxelizePass::createImage(VkPhysicalDevice phys){
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VmaAllocationCreateInfo aci{};
-    aci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
-    if(vmaCreateImage(allocator, &ci, &aci, &voxelImage, &voxelAlloc, nullptr) != VK_SUCCESS)
+    if(!allocateImage(allocator, ci, voxelImage, voxelAlloc))
         return false;
 
     VkImageViewCreateInfo vci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -102,23 +102,3 @@ pytest.skip(
 
 
 
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add allocator helpers for staging, upload, readback, and transient pools
- refactor CSM and voxelize passes to use allocator helpers
- document memory allocation helpers

## Testing
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d258a0c832dbf6dd0049c77bae9