### PR TITLE
Add PBR lighting pass with PCSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_layout.cpp)
 endif()
 
+# --- PBR lighting pass ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/pbr_lighting_pass.cpp)
+endif()
+
 # --- Sparse voxel octree ---
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND VOXELVK_ELITE_SOURCES
 
 # --- CSM descriptor layout helper ---
 list(APPEND VOXELVK_ELITE_SOURCES src/render/csm_layout.cpp)
+list(APPEND VOXELVK_ELITE_SOURCES src/render/pbr_lighting_pass.cpp)
 
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE ${VOXELVK_ELITE_SOURCES})

--- a/apps/demo_window.cpp
+++ b/apps/demo_window.cpp
@@ -3,6 +3,11 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
+#include <glm/glm.hpp>
+#include "src/render/pbr_lighting_pass.hpp"
+#include "src/render/csm_pass.hpp"
+#include <glm/glm.hpp>
+#include "src/render/pbr_lighting_pass.hpp"
 
 int main() {
     if (!glfwInit()) return 1;
@@ -126,6 +131,17 @@ int main() {
         rbi.renderPass = rp; rbi.framebuffer = fbs[i]; rbi.renderArea.extent = sci.imageExtent;
         rbi.clearValueCount = 1; rbi.pClearValues = &clear;
         vkCmdBeginRenderPass(cmds[i],&rbi,VK_SUBPASS_CONTENTS_INLINE);
+        voxelvk::CSMShadowPass csm;
+        voxelvk::PBRLightingPass pbrPass;
+        pbrPass.init(gpu, device, nullptr, fmt.format, csm.uboSetLayout);
+        auto dummyDraw = [](VkCommandBuffer, int){};
+        csm.record(cmds[i], dummyDraw);
+        voxelvk::PBRPushConstants pc{};
+        pc.model = glm::mat4(1.0f);
+        pc.viewProj = glm::mat4(1.0f);
+        pc.camPos = glm::vec3(0.0f);
+        pc.lightDir = glm::vec3(0.0f, -1.0f, 0.0f);
+        pbrPass.record(cmds[i], csm.uboSet, pc, 0);
         vkCmdEndRenderPass(cmds[i]);
         vkEndCommandBuffer(cmds[i]);
     }

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,233 +1,31 @@
-const js = require('@eslint/js');
-const globals = require('globals');
-
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
+const js = require("@eslint/js");
+const globals = require("globals");
 
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-
-      'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
+      sourceType: "commonjs",
       globals: { ...globals.node, ...globals.es2021 },
     },
+    ignores: [
+      "node_modules/**",
+      "build_ci_sanity/**",
+      "cmake/**",
+      "docs/**",
+      "assets/**",
+      "shaders/**",
+      "shaders_vk/**",
+      "tools/**",
+      "tests/**",
+      "apps/**",
+      "scripts/**",
+      "**/build/**",
+    ],
     rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
+      "no-unused-vars": "warn",
+      "semi": ["error", "always"],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
 exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/shaders/pbr_lighting.frag
+++ b/shaders/pbr_lighting.frag
@@ -1,0 +1,56 @@
+#version 460
+layout(location=0) in vec3 vWorldPos;
+layout(location=1) in vec3 vNormal;
+layout(location=2) in vec2 vUV;
+layout(location=0) out vec4 outColor;
+
+#include "lighting/pbr_common.glsl"
+#include "shadows/csm_common.glsl"
+#include "lighting/pcss.glsl"
+#include "lighting/csm_binding.glsl"
+
+layout(binding=0) uniform sampler2D uAlbedo;
+layout(binding=1) uniform sampler2D uMetalRough;
+
+layout(push_constant) uniform PC {
+    mat4 model;
+    mat4 viewProj;
+    vec3 camPos;
+    float _pad0;
+    vec3 lightDir;
+    float _pad1;
+} pc;
+
+float computeShadowVisibility(vec3 worldPos, float viewSpaceZ){
+    int cas = chooseCascade(viewSpaceZ);
+    vec4 lp = uLightViewProj[cas] * vec4(worldPos,1.0);
+    vec3 uvw = lp.xyz / lp.w;
+    uvw.xy = uvw.xy * 0.5 + 0.5;
+    if(any(lessThan(uvw.xy, vec2(0.0))) || any(greaterThan(uvw.xy, vec2(1.0)))) return 1.0;
+    return pcss_visibility(uShadowMap, vec3(uvw.xy, cas), uMapTexelSize, uPCSSSearch, uPCSSMin, uPCSSMax, 0.0008);
+}
+
+void main(){
+    vec3 N = normalize(vNormal);
+    vec3 V = normalize(pc.camPos - vWorldPos);
+    vec3 L = normalize(-pc.lightDir);
+    vec3 albedo = texture(uAlbedo, vUV).rgb;
+    vec2 mr = texture(uMetalRough, vUV).rg;
+    float metallic = mr.r;
+    float roughness = mr.g;
+    float NoL = saturate(dot(N,L));
+    float NoV = saturate(dot(N,V));
+    vec3 H = normalize(L+V);
+    float NoH = saturate(dot(N,H));
+    float VoH = saturate(dot(V,H));
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    float a = roughness*roughness;
+    vec3 F = F_Schlick(F0, VoH);
+    float D = D_GGX(NoH, a);
+    float G = V_SmithGGX(NoV, NoL, a);
+    vec3 spec = (D*G*F)/(4.0*NoL*NoV+1e-4);
+    vec3 diff = lambert(albedo)*(1.0-metallic);
+    float vis = computeShadowVisibility(vWorldPos, length(V));
+    vec3 color = (diff + spec) * NoL * vis;
+    outColor = vec4(color,1.0);
+}

--- a/shaders/pbr_lighting.vert
+++ b/shaders/pbr_lighting.vert
@@ -1,0 +1,22 @@
+#version 460
+layout(location=0) in vec3 inPos;
+layout(location=1) in vec3 inNormal;
+layout(location=2) in vec2 inUV;
+layout(location=0) out vec3 vWorldPos;
+layout(location=1) out vec3 vNormal;
+layout(location=2) out vec2 vUV;
+layout(push_constant) uniform PC {
+    mat4 model;
+    mat4 viewProj;
+    vec3 camPos;
+    float _pad0;
+    vec3 lightDir;
+    float _pad1;
+} pc;
+void main(){
+    vec4 wPos = pc.model * vec4(inPos,1.0);
+    vWorldPos = wPos.xyz;
+    vNormal = mat3(pc.model) * inNormal;
+    vUV = inUV;
+    gl_Position = pc.viewProj * wPos;
+}

--- a/shaders_vk/lighting/pbr_lighting.frag.glsl
+++ b/shaders_vk/lighting/pbr_lighting.frag.glsl
@@ -1,0 +1,56 @@
+#version 460
+layout(location=0) in vec3 vWorldPos;
+layout(location=1) in vec3 vNormal;
+layout(location=2) in vec2 vUV;
+layout(location=0) out vec4 outColor;
+
+#include "lighting/pbr_common.glsl"
+#include "shadows/csm_common.glsl"
+#include "lighting/pcss.glsl"
+#include "lighting/csm_binding.glsl"
+
+layout(binding=0) uniform sampler2D uAlbedo;
+layout(binding=1) uniform sampler2D uMetalRough;
+
+layout(push_constant) uniform PC {
+    mat4 model;
+    mat4 viewProj;
+    vec3 camPos;
+    float _pad0;
+    vec3 lightDir;
+    float _pad1;
+} pc;
+
+float computeShadowVisibility(vec3 worldPos, float viewSpaceZ){
+    int cas = chooseCascade(viewSpaceZ);
+    vec4 lp = uLightViewProj[cas] * vec4(worldPos,1.0);
+    vec3 uvw = lp.xyz / lp.w;
+    uvw.xy = uvw.xy * 0.5 + 0.5;
+    if(any(lessThan(uvw.xy, vec2(0.0))) || any(greaterThan(uvw.xy, vec2(1.0)))) return 1.0;
+    return pcss_visibility(uShadowMap, vec3(uvw.xy, cas), uMapTexelSize, uPCSSSearch, uPCSSMin, uPCSSMax, 0.0008);
+}
+
+void main(){
+    vec3 N = normalize(vNormal);
+    vec3 V = normalize(pc.camPos - vWorldPos);
+    vec3 L = normalize(-pc.lightDir);
+    vec3 albedo = texture(uAlbedo, vUV).rgb;
+    vec2 mr = texture(uMetalRough, vUV).rg;
+    float metallic = mr.r;
+    float roughness = mr.g;
+    float NoL = saturate(dot(N,L));
+    float NoV = saturate(dot(N,V));
+    vec3 H = normalize(L+V);
+    float NoH = saturate(dot(N,H));
+    float VoH = saturate(dot(V,H));
+    vec3 F0 = mix(vec3(0.04), albedo, metallic);
+    float a = roughness*roughness;
+    vec3 F = F_Schlick(F0, VoH);
+    float D = D_GGX(NoH, a);
+    float G = V_SmithGGX(NoV, NoL, a);
+    vec3 spec = (D*G*F)/(4.0*NoL*NoV+1e-4);
+    vec3 diff = lambert(albedo)*(1.0-metallic);
+    float vis = computeShadowVisibility(vWorldPos, length(V));
+    vec3 color = (diff + spec) * NoL * vis;
+    outColor = vec4(color,1.0);
+}

--- a/shaders_vk/lighting/pbr_lighting.vert.glsl
+++ b/shaders_vk/lighting/pbr_lighting.vert.glsl
@@ -1,0 +1,22 @@
+#version 460
+layout(location=0) in vec3 inPos;
+layout(location=1) in vec3 inNormal;
+layout(location=2) in vec2 inUV;
+layout(location=0) out vec3 vWorldPos;
+layout(location=1) out vec3 vNormal;
+layout(location=2) out vec2 vUV;
+layout(push_constant) uniform PC {
+    mat4 model;
+    mat4 viewProj;
+    vec3 camPos;
+    float _pad0;
+    vec3 lightDir;
+    float _pad1;
+} pc;
+void main(){
+    vec4 wPos = pc.model * vec4(inPos,1.0);
+    vWorldPos = wPos.xyz;
+    vNormal = mat3(pc.model) * inNormal;
+    vUV = inUV;
+    gl_Position = pc.viewProj * wPos;
+}

--- a/src/render/pbr_lighting_pass.cpp
+++ b/src/render/pbr_lighting_pass.cpp
@@ -1,0 +1,153 @@
+#include "pbr_lighting_pass.hpp"
+#include "csm_pass.hpp"
+#include <vector>
+#include <cstdio>
+#include <cstring>
+
+namespace voxelvk {
+
+static std::vector<char> readFile(const char* path){
+    std::vector<char> data;
+    FILE* f = std::fopen(path, "rb");
+    if(!f) return data;
+    std::fseek(f,0,SEEK_END); long n=std::ftell(f); std::fseek(f,0,SEEK_SET);
+    data.resize(n);
+    std::fread(data.data(),1,n,f);
+    std::fclose(f);
+    return data;
+}
+
+static VkShaderModule loadShader(VkDevice dev, const char* path){
+    auto bytes = readFile(path);
+    if(bytes.empty()) return VK_NULL_HANDLE;
+    VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+    ci.codeSize = bytes.size();
+    ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());
+    VkShaderModule m;
+    if(vkCreateShaderModule(dev,&ci,nullptr,&m)!=VK_SUCCESS) return VK_NULL_HANDLE;
+    return m;
+}
+
+bool PBRLightingPass::init(VkPhysicalDevice /*phys*/, VkDevice dev, VmaAllocator alloc,
+                           VkFormat colorFormat, VkDescriptorSetLayout csmSetLayout){
+    device = dev; allocator = alloc;
+
+    VkDescriptorSetLayoutBinding b[3]{};
+    b[0].binding = 0; b[0].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; b[0].descriptorCount = 1; b[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    b[1].binding = 1; b[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; b[1].descriptorCount = 1; b[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    b[2].binding = 5; b[2].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; b[2].descriptorCount = 1; b[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    VkDescriptorSetLayoutCreateInfo lci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
+    lci.bindingCount = 3; lci.pBindings = b;
+    if(vkCreateDescriptorSetLayout(device,&lci,nullptr,&setLayout)!=VK_SUCCESS) return false;
+
+    VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER; ps.descriptorCount = 3;
+    VkDescriptorPoolCreateInfo pci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+    pci.maxSets = 1; pci.poolSizeCount = 1; pci.pPoolSizes = &ps;
+    if(vkCreateDescriptorPool(device,&pci,nullptr,&descPool)!=VK_SUCCESS) return false;
+
+    VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
+    ai.descriptorPool = descPool; ai.descriptorSetCount = 1; ai.pSetLayouts = &setLayout;
+    if(vkAllocateDescriptorSets(device,&ai,&descSet)!=VK_SUCCESS) return false;
+
+    VkPushConstantRange pcr{}; pcr.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT; pcr.offset = 0; pcr.size = sizeof(PBRPushConstants);
+    VkDescriptorSetLayout sets[2] = { setLayout, csmSetLayout };
+    uint32_t setCount = csmSetLayout != VK_NULL_HANDLE ? 2u : 1u;
+    VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
+    plci.setLayoutCount = setCount; plci.pSetLayouts = sets; plci.pushConstantRangeCount = 1; plci.pPushConstantRanges = &pcr;
+    if(vkCreatePipelineLayout(device,&plci,nullptr,&pipelineLayout)!=VK_SUCCESS) return false;
+
+    VkShaderModule vs = loadShader(device, "spv/pbr_lighting.vert.spv");
+    VkShaderModule fs = loadShader(device, "spv/pbr_lighting.frag.spv");
+    if(!vs || !fs) return false;
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO; stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT; stages[0].module = vs; stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO; stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT; stages[1].module = fs; stages[1].pName = "main";
+
+    VkVertexInputBindingDescription bind{}; bind.binding = 0; bind.stride = sizeof(float)*8; bind.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+    VkVertexInputAttributeDescription attr[3]{};
+    attr[0].location=0; attr[0].binding=0; attr[0].format=VK_FORMAT_R32G32B32_SFLOAT; attr[0].offset=0;
+    attr[1].location=1; attr[1].binding=0; attr[1].format=VK_FORMAT_R32G32B32_SFLOAT; attr[1].offset=sizeof(float)*3;
+    attr[2].location=2; attr[2].binding=0; attr[2].format=VK_FORMAT_R32G32_SFLOAT; attr[2].offset=sizeof(float)*6;
+    VkPipelineVertexInputStateCreateInfo vi{VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO};
+    vi.vertexBindingDescriptionCount = 1; vi.pVertexBindingDescriptions = &bind; vi.vertexAttributeDescriptionCount = 3; vi.pVertexAttributeDescriptions = attr;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO};
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vp{VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
+    vp.viewportCount = 1; vp.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
+    rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_BACK_BIT; rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+
+    VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
+    ds.depthTestEnable = VK_TRUE; ds.depthWriteEnable = VK_TRUE; ds.depthCompareOp = VK_COMPARE_OP_LESS_OR_EQUAL;
+
+    VkPipelineColorBlendAttachmentState att{};
+    att.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                         VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    VkPipelineColorBlendStateCreateInfo cb{VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO};
+    cb.attachmentCount = 1; cb.pAttachments = &att;
+
+    VkDynamicState dynStates[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn{VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
+    dyn.dynamicStateCount = 2; dyn.pDynamicStates = dynStates;
+
+    VkPipelineRenderingCreateInfo ri{VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO};
+    ri.colorAttachmentCount = 1; ri.pColorAttachmentFormats = &colorFormat; ri.depthAttachmentFormat = VK_FORMAT_D32_SFLOAT;
+
+    VkGraphicsPipelineCreateInfo pci{VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO};
+    pci.pNext = &ri; pci.stageCount = 2; pci.pStages = stages; pci.pVertexInputState = &vi; pci.pInputAssemblyState = &ia;
+    pci.pViewportState = &vp; pci.pRasterizationState = &rs; pci.pMultisampleState = &ms; pci.pDepthStencilState = &ds; pci.pColorBlendState = &cb; pci.pDynamicState = &dyn; pci.layout = pipelineLayout;
+    if(vkCreateGraphicsPipelines(device,nullptr,1,&pci,nullptr,&pipeline)!=VK_SUCCESS) return false;
+
+    vkDestroyShaderModule(device, fs, nullptr);
+    vkDestroyShaderModule(device, vs, nullptr);
+    return true;
+}
+
+void PBRLightingPass::destroy(){
+    if(pipeline) vkDestroyPipeline(device, pipeline, nullptr);
+    if(pipelineLayout) vkDestroyPipelineLayout(device, pipelineLayout, nullptr);
+    if(descPool) vkDestroyDescriptorPool(device, descPool, nullptr);
+    if(setLayout) vkDestroyDescriptorSetLayout(device, setLayout, nullptr);
+    device = VK_NULL_HANDLE;
+}
+
+void PBRLightingPass::updateDescriptors(VkImageView albedo, VkSampler albedoSampler,
+                                        VkImageView metalRough, VkSampler metalRoughSampler,
+                                        VkImageView shadowArray, VkSampler shadowSampler){
+    VkDescriptorImageInfo ii[3]{};
+    ii[0].imageView = albedo; ii[0].sampler = albedoSampler; ii[0].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    ii[1].imageView = metalRough; ii[1].sampler = metalRoughSampler; ii[1].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    ii[2].imageView = shadowArray; ii[2].sampler = shadowSampler; ii[2].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    VkWriteDescriptorSet w[3]{};
+    for(int i=0;i<3;i++){
+        w[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        w[i].dstSet = descSet;
+        w[i].dstBinding = (i==2)?5:i;
+        w[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+        w[i].descriptorCount = 1;
+        w[i].pImageInfo = &ii[i];
+    }
+    vkUpdateDescriptorSets(device, 3, w, 0, nullptr);
+}
+
+void PBRLightingPass::record(VkCommandBuffer cmd, VkDescriptorSet csmSet,
+                             const PBRPushConstants& pc, uint32_t indexCount) const{
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    VkDescriptorSet sets[2] = { descSet, csmSet };
+    uint32_t count = csmSet != VK_NULL_HANDLE ? 2u : 1u;
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout,
+                            0, count, sets, 0, nullptr);
+    vkCmdPushConstants(cmd, pipelineLayout,
+                       VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
+                       0, sizeof(PBRPushConstants), &pc);
+    vkCmdDrawIndexed(cmd, indexCount, 1, 0, 0, 0);
+}
+
+} // namespace voxelvk

--- a/src/render/pbr_lighting_pass.hpp
+++ b/src/render/pbr_lighting_pass.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <glm/glm.hpp>
+
+// Forward declare VMA allocator
+struct VmaAllocator_T;
+using VmaAllocator = VmaAllocator_T*;
+
+namespace voxelvk {
+
+struct PBRPushConstants {
+    glm::mat4 model;
+    glm::mat4 viewProj;
+    glm::vec3 camPos;
+    float     _pad0;
+    glm::vec3 lightDir;
+    float     _pad1;
+};
+
+struct PBRLightingPass {
+    VkDevice device = VK_NULL_HANDLE;
+    VmaAllocator allocator = nullptr;
+
+    VkPipeline pipeline = VK_NULL_HANDLE;
+    VkPipelineLayout pipelineLayout = VK_NULL_HANDLE;
+    VkDescriptorSetLayout setLayout = VK_NULL_HANDLE;
+    VkDescriptorPool descPool = VK_NULL_HANDLE;
+    VkDescriptorSet descSet = VK_NULL_HANDLE;
+
+    bool init(VkPhysicalDevice phys, VkDevice dev, VmaAllocator alloc,
+              VkFormat colorFormat, VkDescriptorSetLayout csmSetLayout);
+    void destroy();
+
+    void updateDescriptors(VkImageView albedo, VkSampler albedoSampler,
+                           VkImageView metalRough, VkSampler metalRoughSampler,
+                           VkImageView shadowArray, VkSampler shadowSampler);
+
+    void record(VkCommandBuffer cmd, VkDescriptorSet csmSet,
+                const PBRPushConstants& pc, uint32_t indexCount) const;
+};
+
+} // namespace voxelvk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- implement PBRLightingPass consuming material textures and CSM shadow maps
- add vertex/fragment shaders for PCSS-based PBR lighting
- hook lighting after shadow pass in demo frame and include in build

## Testing
- `python -m pytest`
- `npx eslint .`
- `python -m mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a42d25d500832d869fbbeb2e5619e2