### PR TITLE
Add shader hot-reload with ImGui overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,4 +178,9 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
+
+# --- ImGui overlay layer ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/imgui_layer.cpp)
+endif()
         main

--- a/apps/demo_window.cpp
+++ b/apps/demo_window.cpp
@@ -3,6 +3,56 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <unordered_map>
+#include <string>
+
+#include "render/imgui_layer.hpp"
+
+namespace fs = std::filesystem;
+
+struct ShaderEntry {
+    VkShaderModule module{VK_NULL_HANDLE};
+    fs::file_time_type timestamp{};
+};
+
+static std::unordered_map<std::string, ShaderEntry> gShaders;
+
+static void LoadShader(VkDevice device, const std::string& path) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) return;
+    size_t size = (size_t)file.tellg();
+    std::vector<char> buffer(size);
+    file.seekg(0);
+    file.read(buffer.data(), size);
+    VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
+    ci.codeSize = buffer.size();
+    ci.pCode = reinterpret_cast<const uint32_t*>(buffer.data());
+    VkShaderModule module;
+    if (vkCreateShaderModule(device, &ci, nullptr, &module) == VK_SUCCESS) {
+        auto it = gShaders.find(path);
+        if (it != gShaders.end()) {
+            vkDestroyShaderModule(device, it->second.module, nullptr);
+        }
+        gShaders[path] = {module, fs::last_write_time(path)};
+        std::cout << "Loaded " << path << "\n";
+    }
+}
+
+static void ScanShaders(VkDevice device) {
+    fs::path dir{"shaders"};
+    if (!fs::exists(dir)) return;
+    for (const auto& entry : fs::directory_iterator(dir)) {
+        if (entry.path().extension() != ".spv") continue;
+        std::string path = entry.path().string();
+        auto stamp = fs::last_write_time(entry);
+        auto it = gShaders.find(path);
+        if (it == gShaders.end() || it->second.timestamp != stamp) {
+            LoadShader(device, path);
+        }
+    }
+}
 
 int main() {
     if (!glfwInit()) return 1;
@@ -67,6 +117,13 @@ int main() {
     VkDevice device;
     if(vkCreateDevice(gpu,&dci,nullptr,&device)!=VK_SUCCESS){ std::cerr<<"vkCreateDevice failed\n"; return 6; }
     VkQueue queue; vkGetDeviceQueue(device,graphicsQueue,0,&queue);
+
+    // Initial shader load
+    ScanShaders(device);
+    bool autoReload = true;
+    bool debugToggle = false;
+    bool requestReload = false;
+    voxelvk::render::ImGuiLayer imgui;
 
     // Swapchain
     VkSurfaceCapabilitiesKHR caps; vkGetPhysicalDeviceSurfaceCapabilitiesKHR(gpu,surface,&caps);
@@ -137,6 +194,10 @@ int main() {
 
     while(!glfwWindowShouldClose(window)){
         glfwPollEvents();
+        imgui.begin();
+        imgui.draw(requestReload, autoReload, debugToggle);
+        imgui.end();
+        if (autoReload || requestReload) { ScanShaders(device); requestReload = false; }
         uint32_t imgIndex; vkAcquireNextImageKHR(device,swapchain,UINT64_MAX,imgAvailable,VK_NULL_HANDLE,&imgIndex);
         VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
@@ -159,6 +220,7 @@ int main() {
     vkDestroyRenderPass(device,rp,nullptr);
     for(auto v:views) vkDestroyImageView(device,v,nullptr);
     vkDestroySwapchainKHR(device,swapchain,nullptr);
+    for(auto& kv : gShaders) vkDestroyShaderModule(device, kv.second.module, nullptr);
     vkDestroyDevice(device,nullptr);
     vkDestroySurfaceKHR(instance,surface,nullptr);
     vkDestroyInstance(instance,nullptr);

--- a/src/render/imgui_layer.cpp
+++ b/src/render/imgui_layer.cpp
@@ -1,0 +1,40 @@
+#include "render/imgui_layer.hpp"
+
+#if defined(ENABLE_IMGUI_OVERLAY) && ENABLE_IMGUI_OVERLAY
+# if __has_include("imgui.h")
+#  include "imgui.h"
+#  define VOXELVK_HAS_IMGUI 1
+# endif
+#endif
+#ifndef VOXELVK_HAS_IMGUI
+#define VOXELVK_HAS_IMGUI 0
+#endif
+
+namespace voxelvk::render {
+
+void ImGuiLayer::begin() {
+#if VOXELVK_HAS_IMGUI
+  ImGui::NewFrame();
+#endif
+}
+
+void ImGuiLayer::end() {
+#if VOXELVK_HAS_IMGUI
+  ImGui::Render();
+#endif
+}
+
+void ImGuiLayer::draw(bool &reloadRequest, bool &autoReload, bool &debugToggle) {
+#if VOXELVK_HAS_IMGUI
+  if (ImGui::Begin("Debug")) {
+    if (ImGui::Button("Reload Shaders")) reloadRequest = true;
+    ImGui::Checkbox("Auto Reload", &autoReload);
+    ImGui::Checkbox("Debug", &debugToggle);
+    ImGui::End();
+  }
+#else
+  (void)reloadRequest; (void)autoReload; (void)debugToggle;
+#endif
+}
+
+} // namespace voxelvk::render

--- a/src/render/imgui_layer.hpp
+++ b/src/render/imgui_layer.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdbool.h>
+
+namespace voxelvk::render {
+struct ImGuiLayer {
+  void begin();
+  void end();
+  void draw(bool &reloadRequest, bool &autoReload, bool &debugToggle);
+};
+} // namespace voxelvk::render
+


### PR DESCRIPTION
## Summary
- watch `shaders/` directory for modified SPIR-V and reload when updated
- wrap Dear ImGui usage in `ImGuiLayer` helper and expose basic overlay controls
- hook in CMake so the new layer compiles with the renderer

## Testing
- `pip install -r requirements.txt`
- `npx eslint -c /dev/null .`
- `mypy --config-file /tmp/empty_mypy.ini tests` *(fails: Unexpected indent)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*


------
https://chatgpt.com/codex/tasks/task_e_68a42d2b5f2c832db4535e970b3e573b