### PR TITLE
Add Vulkan barrier utilities and basic frame graph

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,103 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
-      sourceType: 'script',
+      sourceType: 'commonjs',
       globals: { ...globals.node, ...globals.es2021 }
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
+      'build/**',
       'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
@@ -107,127 +20,12 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
+      'node_modules/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
       semi: ['error', 'always']
     }
   }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/vk/barrier_helpers.hpp
+++ b/src/vk/barrier_helpers.hpp
@@ -31,6 +31,88 @@ inline void transition_image(VkCommandBuffer cmd,
     vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
 }
 
+inline void transition_buffer(VkCommandBuffer cmd,
+                              VkBuffer buffer,
+                              VkAccessFlags srcAccess,
+                              VkAccessFlags dstAccess,
+                              VkPipelineStageFlags srcStage,
+                              VkPipelineStageFlags dstStage,
+                              VkDeviceSize offset = 0,
+                              VkDeviceSize size = VK_WHOLE_SIZE) {
+    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccess;
+    barrier.dstAccessMask = dstAccess;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.buffer = buffer;
+    barrier.offset = offset;
+    barrier.size = size;
+
+    vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+}
+
+inline void memory_barrier(VkCommandBuffer cmd,
+                           VkAccessFlags srcAccess,
+                           VkAccessFlags dstAccess,
+                           VkPipelineStageFlags srcStage,
+                           VkPipelineStageFlags dstStage) {
+    VkMemoryBarrier barrier{VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccess;
+    barrier.dstAccessMask = dstAccess;
+    vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 1, &barrier, 0, nullptr, 0, nullptr);
+}
+
+inline void transfer_image_ownership(VkCommandBuffer cmd,
+                                     VkImage image,
+                                     VkImageLayout layout,
+                                     VkAccessFlags srcAccess,
+                                     VkAccessFlags dstAccess,
+                                     VkPipelineStageFlags srcStage,
+                                     VkPipelineStageFlags dstStage,
+                                     uint32_t srcQueue,
+                                     uint32_t dstQueue,
+                                     VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                                     uint32_t baseMip = 0, uint32_t levelCount = 1,
+                                     uint32_t baseLayer = 0, uint32_t layerCount = 1) {
+    VkImageMemoryBarrier barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccess;
+    barrier.dstAccessMask = dstAccess;
+    barrier.oldLayout = layout;
+    barrier.newLayout = layout;
+    barrier.srcQueueFamilyIndex = srcQueue;
+    barrier.dstQueueFamilyIndex = dstQueue;
+    barrier.image = image;
+    barrier.subresourceRange.aspectMask = aspectMask;
+    barrier.subresourceRange.baseMipLevel = baseMip;
+    barrier.subresourceRange.levelCount = levelCount;
+    barrier.subresourceRange.baseArrayLayer = baseLayer;
+    barrier.subresourceRange.layerCount = layerCount;
+
+    vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 0, nullptr, 1, &barrier);
+}
+
+inline void transfer_buffer_ownership(VkCommandBuffer cmd,
+                                      VkBuffer buffer,
+                                      VkAccessFlags srcAccess,
+                                      VkAccessFlags dstAccess,
+                                      VkPipelineStageFlags srcStage,
+                                      VkPipelineStageFlags dstStage,
+                                      uint32_t srcQueue,
+                                      uint32_t dstQueue,
+                                      VkDeviceSize offset = 0,
+                                      VkDeviceSize size = VK_WHOLE_SIZE) {
+    VkBufferMemoryBarrier barrier{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    barrier.srcAccessMask = srcAccess;
+    barrier.dstAccessMask = dstAccess;
+    barrier.srcQueueFamilyIndex = srcQueue;
+    barrier.dstQueueFamilyIndex = dstQueue;
+    barrier.buffer = buffer;
+    barrier.offset = offset;
+    barrier.size = size;
+
+    vkCmdPipelineBarrier(cmd, srcStage, dstStage, 0, 0, nullptr, 1, &barrier, 0, nullptr);
+}
+
 inline VkAccessFlags access_for_layout(VkImageLayout layout) {
     switch(layout){
         case VK_IMAGE_LAYOUT_GENERAL: return VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT;

--- a/src/vk/frame_graph.hpp
+++ b/src/vk/frame_graph.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+#include "barrier_helpers.hpp"
+
+namespace vkx {
+
+struct ImageState {
+    VkImageLayout layout;
+    VkAccessFlags access;
+    VkPipelineStageFlags stage;
+};
+
+struct BufferState {
+    VkAccessFlags access;
+    VkPipelineStageFlags stage;
+};
+
+struct Pass {
+    std::function<void(VkCommandBuffer)> record;
+    std::unordered_map<VkImage, ImageState> images;
+    std::unordered_map<VkBuffer, BufferState> buffers;
+};
+
+class FrameGraph {
+    std::vector<Pass> passes;
+
+public:
+    Pass &add_pass(std::function<void(VkCommandBuffer)> cb) {
+        passes.push_back({cb});
+        return passes.back();
+    }
+
+    void execute(VkCommandBuffer cmd) {
+        std::unordered_map<VkImage, ImageState> imageStates;
+        std::unordered_map<VkBuffer, BufferState> bufferStates;
+
+        for (auto &p : passes) {
+            for (auto &[img, desired] : p.images) {
+                auto it = imageStates.find(img);
+                if (it != imageStates.end()) {
+                    if (it->second.layout != desired.layout ||
+                        it->second.access != desired.access) {
+                        transition_image(cmd, img, it->second.layout, desired.layout,
+                                         it->second.access, desired.access,
+                                         it->second.stage, desired.stage);
+                        it->second = desired;
+                    }
+                } else {
+                    imageStates[img] = desired;
+                }
+            }
+
+            for (auto &[buf, desired] : p.buffers) {
+                auto it = bufferStates.find(buf);
+                if (it != bufferStates.end()) {
+                    if (it->second.access != desired.access) {
+                        transition_buffer(cmd, buf, it->second.access, desired.access,
+                                          it->second.stage, desired.stage);
+                        it->second = desired;
+                    }
+                } else {
+                    bufferStates[buf] = desired;
+                }
+            }
+
+            p.record(cmd);
+        }
+    }
+};
+
+} // namespace vkx
+

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add helpers for buffer transitions, memory barriers, and queue ownership transfers
- introduce a minimal frame graph that tracks resource states and emits barriers between passes
- clean up test and tool configs so automated checks run

## Testing
- `npx eslint .`
- `mypy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a42d349c58832d9cff218cae6b5bf6