### PR TITLE
Add frustum culling and indirect draw buffer for chunk rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE src/render/csm_layout.cpp)
 endif()
 
+# --- Chunk drawer ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/render/chunk_drawer.cpp)
+endif()
+
 # --- Sparse voxel octree ---
 if(TARGET VoxelVK_Elite_ALL)
   target_sources(VoxelVK_Elite_ALL PRIVATE

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
       '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,13 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
       semi: ['error', 'always'],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/render/chunk_drawer.cpp
+++ b/src/render/chunk_drawer.cpp
@@ -1,0 +1,154 @@
+#include "chunk_drawer.hpp"
+#include <cstring>
+#include <vector>
+
+#include <glm/gtc/matrix_access.hpp>
+
+#include "vk_mem_alloc.h"
+
+namespace voxelvk {
+
+namespace {
+
+ChunkDrawer::Frustum makeFrustum(const glm::mat4 &vp) {
+  ChunkDrawer::Frustum f{};
+  // Left
+  f.planes[0] = glm::row(vp, 3) + glm::row(vp, 0);
+  // Right
+  f.planes[1] = glm::row(vp, 3) - glm::row(vp, 0);
+  // Bottom
+  f.planes[2] = glm::row(vp, 3) + glm::row(vp, 1);
+  // Top
+  f.planes[3] = glm::row(vp, 3) - glm::row(vp, 1);
+  // Near
+  f.planes[4] = glm::row(vp, 3) + glm::row(vp, 2);
+  // Far
+  f.planes[5] = glm::row(vp, 3) - glm::row(vp, 2);
+
+  for (auto &p : f.planes) {
+    float invLen = 1.0f / glm::length(glm::vec3(p));
+    p *= invLen;
+  }
+  return f;
+}
+
+bool aabbInsideFrustum(const ChunkDrawer::Frustum &fr, const glm::vec3 &mn,
+                       const glm::vec3 &mx) {
+  for (const auto &p : fr.planes) {
+    glm::vec3 corner{p.x > 0 ? mx.x : mn.x, p.y > 0 ? mx.y : mn.y,
+                     p.z > 0 ? mx.z : mn.z};
+    if (glm::dot(glm::vec3(p), corner) + p.w < 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+bool ChunkDrawer::init(VkDevice device, VmaAllocator allocator,
+                       std::size_t maxBatches) {
+  device_ = device;
+  allocator_ = allocator;
+  capacity_ = maxBatches;
+
+  if (maxBatches == 0) {
+    return true;
+  }
+
+  VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+  bi.size = maxBatches * sizeof(VkDrawIndexedIndirectCommand);
+  bi.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+
+  VmaAllocationCreateInfo aci{};
+  aci.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+  if (vmaCreateBuffer(allocator_, &bi, &aci, &indirectBuffer_, &indirectAlloc_,
+                      nullptr) != VK_SUCCESS) {
+    indirectBuffer_ = VK_NULL_HANDLE;
+    indirectAlloc_ = nullptr;
+    return false;
+  }
+  return true;
+}
+
+void ChunkDrawer::destroy() {
+  if (indirectBuffer_) {
+    vmaDestroyBuffer(allocator_, indirectBuffer_, indirectAlloc_);
+    indirectBuffer_ = VK_NULL_HANDLE;
+    indirectAlloc_ = nullptr;
+  }
+  batches_.clear();
+  occlusionResults_.clear();
+}
+
+void ChunkDrawer::setBatches(const std::vector<ChunkBatch> &batches) {
+  batches_ = batches;
+}
+
+void ChunkDrawer::setOcclusionResults(const std::vector<uint64_t> &results) {
+  occlusionResults_ = results;
+}
+
+ChunkDrawer::Frustum ChunkDrawer::extractFrustum(const glm::mat4 &vp) {
+  return makeFrustum(vp);
+}
+
+bool ChunkDrawer::aabbInside(const Frustum &fr, const glm::vec3 &mn,
+                             const glm::vec3 &mx) {
+  return aabbInsideFrustum(fr, mn, mx);
+}
+
+bool ChunkDrawer::ensureCapacity(std::size_t count) {
+  if (count <= capacity_) {
+    return true;
+  }
+  destroy();
+  capacity_ = count;
+  VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+  bi.size = capacity_ * sizeof(VkDrawIndexedIndirectCommand);
+  bi.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
+  VmaAllocationCreateInfo aci{};
+  aci.usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+  return vmaCreateBuffer(allocator_, &bi, &aci, &indirectBuffer_,
+                         &indirectAlloc_, nullptr) == VK_SUCCESS;
+}
+
+void ChunkDrawer::record(VkCommandBuffer cmd, const glm::mat4 &view,
+                         const glm::mat4 &proj) {
+  glm::mat4 vp = proj * view;
+  auto fr = extractFrustum(vp);
+  std::vector<VkDrawIndexedIndirectCommand> visible;
+  visible.reserve(batches_.size());
+
+  for (std::size_t i = 0; i < batches_.size(); ++i) {
+    const auto &b = batches_[i];
+    if (!aabbInside(fr, b.minBounds, b.maxBounds)) {
+      continue;
+    }
+    if (useOcclusion_ && i < occlusionResults_.size() &&
+        occlusionResults_[i] == 0) {
+      continue;
+    }
+    visible.push_back(b.drawCmd);
+  }
+
+  if (visible.empty()) {
+    return;
+  }
+
+  if (!ensureCapacity(visible.size())) {
+    return;
+  }
+
+  void *data = nullptr;
+  vmaMapMemory(allocator_, indirectAlloc_, &data);
+  std::memcpy(data, visible.data(),
+              visible.size() * sizeof(VkDrawIndexedIndirectCommand));
+  vmaUnmapMemory(allocator_, indirectAlloc_);
+
+  vkCmdDrawIndexedIndirect(cmd, indirectBuffer_, 0,
+                           static_cast<uint32_t>(visible.size()),
+                           sizeof(VkDrawIndexedIndirectCommand));
+}
+
+} // namespace voxelvk

--- a/src/render/chunk_drawer.hpp
+++ b/src/render/chunk_drawer.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <glm/glm.hpp>
+#include <vector>
+#include <vulkan/vulkan.h>
+
+struct VmaAllocator_T;
+using VmaAllocator = VmaAllocator_T *;
+struct VmaAllocation_T;
+using VmaAllocation = VmaAllocation_T *;
+
+namespace voxelvk {
+
+struct ChunkBatch {
+  glm::vec3 minBounds;
+  glm::vec3 maxBounds;
+  VkDrawIndexedIndirectCommand drawCmd{};
+};
+
+class ChunkDrawer {
+public:
+  bool init(VkDevice device, VmaAllocator allocator,
+            std::size_t maxBatches = 0);
+  void destroy();
+
+  void setBatches(const std::vector<ChunkBatch> &batches);
+  void setOcclusionResults(const std::vector<uint64_t> &results);
+  void enableOcclusionCulling(bool enable) { useOcclusion_ = enable; }
+
+  void record(VkCommandBuffer cmd, const glm::mat4 &view,
+              const glm::mat4 &proj);
+
+private:
+  VkDevice device_ = VK_NULL_HANDLE;
+  VmaAllocator allocator_ = nullptr;
+  VkBuffer indirectBuffer_ = VK_NULL_HANDLE;
+  VmaAllocation indirectAlloc_ = nullptr;
+  std::size_t capacity_ = 0;
+
+  std::vector<ChunkBatch> batches_;
+  std::vector<uint64_t> occlusionResults_;
+  bool useOcclusion_ = false;
+
+  struct Frustum {
+    glm::vec4 planes[6];
+  };
+
+  static Frustum extractFrustum(const glm::mat4 &vp);
+  static bool aabbInside(const Frustum &fr, const glm::vec3 &mn,
+                         const glm::vec3 &mx);
+  bool ensureCapacity(std::size_t count);
+};
+
+} // namespace voxelvk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -86,39 +86,3 @@ def test_sprint_speed_limit():
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- Implement ChunkDrawer with view frustum extraction and optional occlusion culling
- Build indirect draw buffer and submit visible batches via vkCmdDrawIndexedIndirect
- Clean up test and lint/type-check configs

## Testing
- `pytest`
- `mypy .`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d3b44e0832d8841421c5253c6bc