### PR TITLE
Integrate zstd/lz4 and maintain chunk manifest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ set(VOXELVK_BRANCH_SOURCES "project_fixed + VoxelVK_Elite_ALL_release_ready + vo
 include(${CMAKE_SOURCE_DIR}/cmake/GenBuildInfo.cmake)
 include_directories(${CMAKE_BINARY_DIR}/generated)
 
+add_subdirectory(external)
+
 find_package(glfw3 QUIET)
 if(glfw3_FOUND)
   set(GLFW_LIB glfw)
@@ -178,4 +180,7 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
-        main
+
+if(TARGET VoxelVK_Elite_ALL)
+  target_link_libraries(VoxelVK_Elite_ALL PRIVATE ZSTD::ZSTD LZ4::lz4)
+endif()

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,13 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
+      'semi': ['error', 'always'],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  zstd
+  URL https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz
+  SOURCE_SUBDIR build/cmake
+)
+FetchContent_MakeAvailable(zstd)
+add_library(ZSTD::ZSTD ALIAS libzstd_static)
+
+FetchContent_Declare(
+  lz4
+  URL https://github.com/lz4/lz4/archive/refs/tags/v1.9.4.tar.gz
+  SOURCE_SUBDIR build/cmake
+)
+FetchContent_MakeAvailable(lz4)
+add_library(LZ4::lz4 ALIAS lz4_static)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/world/persistence.cpp
+++ b/src/world/persistence.cpp
@@ -5,6 +5,9 @@
 #include <iterator>
 #include <algorithm>
 #include <iostream>
+#include <set>
+#include <sstream>
+#include <cstdio>
 
 #if __has_include(<zstd.h>)
 #define VOXELVK_HAS_ZSTD 1
@@ -35,9 +38,30 @@ std::filesystem::path ChunkStore::_region_dir(int cx, int cz) const {
     return d;
 }
 
-std::filesystem::path ChunkStore::chunk_path(int cx, int cz) const {
-    return _region_dir(cx, cz) / ("c." + std::to_string(cx) + "." + std::to_string(cz) + ".bin");
-}
+  std::filesystem::path ChunkStore::chunk_path(int cx, int cz) const {
+      return _region_dir(cx, cz) / ("c." + std::to_string(cx) + "." + std::to_string(cz) + ".bin");
+  }
+
+  std::filesystem::path ChunkStore::_index_path(int cx, int cz) const {
+      return _region_dir(cx, cz) / "index.txt";
+  }
+
+  void ChunkStore::_update_index(int cx, int cz) {
+      auto idx = _index_path(cx, cz);
+      std::ifstream in(idx);
+      std::string line;
+      while (std::getline(in, line)) {
+          std::istringstream iss(line);
+          int x = 0, z = 0;
+          if (iss >> x >> z) {
+              if (x == cx && z == cz) {
+                  return;
+              }
+          }
+      }
+      std::ofstream out(idx, std::ios::app);
+      out << cx << ' ' << cz << '\n';
+  }
 
 void ChunkStore::rle_encode(const std::vector<std::uint8_t> &arr,
                             std::vector<std::uint8_t> &vals,
@@ -171,11 +195,7 @@ void ChunkStore::save_chunk_sync(const Chunk &chunk) {
     std::ofstream ofs(path, std::ios::binary);
     ofs.write(reinterpret_cast<const char *>(blob.data()), static_cast<std::streamsize>(blob.size()));
     ofs.close();
-
-    // Minimal index.json write
-    auto idx = _region_dir(cx, cz) / "index.json";
-    std::ofstream idxf(idx, std::ios::binary);
-    idxf << "{\"" << cx << "," << cz << "\": {\"saved\": true}}";
+    _update_index(cx, cz);
 }
 
 void ChunkStore::save_async(const Chunk &chunk) {
@@ -206,7 +226,36 @@ std::optional<ChunkData> ChunkStore::load_chunk(int cx, int cz) {
     } else {
         vox.assign(ptr, ptr + static_cast<std::size_t>(H) * Y * S);
     }
-    return ChunkData{std::move(vox), Y, S};
+  return ChunkData{std::move(vox), Y, S};
+}
+
+void ChunkStore::compact_region(int rx, int rz) {
+    auto dir = root_ / ("r." + std::to_string(rx) + "." + std::to_string(rz));
+    if (!std::filesystem::exists(dir)) return;
+    std::set<std::pair<int, int>> chunks;
+    for (auto &p : std::filesystem::directory_iterator(dir)) {
+        if (p.path().extension() == ".bin") {
+            int cx = 0, cz = 0;
+            if (std::sscanf(p.path().filename().string().c_str(), "c.%d.%d.bin", &cx, &cz) == 2) {
+                chunks.emplace(cx, cz);
+            }
+        }
+    }
+    std::ofstream idx(dir / "index.txt", std::ios::trunc);
+    for (auto [cx, cz] : chunks) {
+        idx << cx << ' ' << cz << '\n';
+    }
+}
+
+void ChunkStore::compact_all() {
+    for (auto &p : std::filesystem::directory_iterator(root_)) {
+        if (p.is_directory()) {
+            int rx = 0, rz = 0;
+            if (std::sscanf(p.path().filename().string().c_str(), "r.%d.%d", &rx, &rz) == 2) {
+                compact_region(rx, rz);
+            }
+        }
+    }
 }
 
 void ChunkStore::wait_all() {

--- a/src/world/persistence.hpp
+++ b/src/world/persistence.hpp
@@ -37,11 +37,15 @@ public:
     void save_async(const Chunk &chunk);
     std::optional<ChunkData> load_chunk(int cx, int cz);
     void wait_all();
+    void compact_region(int rx, int rz);
+    void compact_all();
 
 private:
     std::filesystem::path _region_dir(int cx, int cz) const;
     std::vector<std::uint8_t> _compress(const std::vector<std::uint8_t> &data) const;
     std::vector<std::uint8_t> _decompress(const std::vector<std::uint8_t> &data) const;
+    std::filesystem::path _index_path(int cx, int cz) const;
+    void _update_index(int cx, int cz);
 
     static void rle_encode(const std::vector<std::uint8_t> &arr,
                            std::vector<std::uint8_t> &vals,
@@ -58,4 +62,3 @@ private:
 };
 
 } // namespace world
-

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,37 +88,7 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- Fetch zstd and lz4 with CMake FetchContent and link into build
- Track chunk files in a region manifest with compaction helpers
- Clean up tests and build configs for tooling

## Testing
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d3f824c832d9312af823e9466f3