### PR TITLE
Integrate Vulkan Memory Allocator and add allocation wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,17 @@ if(ENABLE_VULKAN)
   endif()
 endif()
 
+# ---- External: Vulkan Memory Allocator ----
+if(ENABLE_VULKAN)
+  include(FetchContent)
+  FetchContent_Declare(
+    VulkanMemoryAllocator
+    GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+    GIT_TAG v3.3.0
+  )
+  FetchContent_MakeAvailable(VulkanMemoryAllocator)
+endif()
+
 # --- Build tagging injection ---
 set(VOXELVK_BRANCH_SOURCES "project_fixed + VoxelVK_Elite_ALL_release_ready + voxel_upgrades_patch + project_compute_graphics_chain + project_dynamic_pbr + project_next_tier_all")
 include(${CMAKE_SOURCE_DIR}/cmake/GenBuildInfo.cmake)
@@ -113,12 +124,18 @@ if(ENABLE_VULKAN)
   add_executable(smoke_headless apps/smoke_headless.cpp)
   add_dependencies(smoke_headless VoxelVK_Shaders)
   target_include_directories(smoke_headless PRIVATE ${CMAKE_SOURCE_DIR}/src)
-  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB})
+  target_sources(smoke_headless PRIVATE src/vk/vma_allocator.cpp)
+  target_link_libraries(smoke_headless PRIVATE Vulkan::Vulkan Threads::Threads ${GLFW_LIB} GPUOpen::VulkanMemoryAllocator)
   target_compile_definitions(smoke_headless PRIVATE
     $<$<BOOL:${ENABLE_VALIDATION_LAYERS}>:ENABLE_VALIDATION_LAYERS=1>
     $<$<BOOL:${ENABLE_IMGUI_OVERLAY}>:ENABLE_IMGUI_OVERLAY=1>
     $<$<BOOL:${VOXELVK_ENABLE_CUDA}>:VOXELVK_ENABLE_CUDA=1>
     $<$<BOOL:${VOXELVK_ENABLE_TENSORRT}>:VOXELVK_ENABLE_TENSORRT=1>)
+endif()
+
+if(ENABLE_VULKAN AND TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/vk/vma_allocator.cpp)
+  target_link_libraries(VoxelVK_Elite_ALL PRIVATE GPUOpen::VulkanMemoryAllocator)
 endif()
 
 # Tests
@@ -178,4 +195,3 @@ endif()
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
-        main

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,9 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
       'scripts/**',
     ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
-    },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
 exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/src/vk/vma_allocator.cpp
+++ b/src/vk/vma_allocator.cpp
@@ -1,0 +1,51 @@
+#define VMA_IMPLEMENTATION
+#include <vk_mem_alloc.h>
+
+#include "vma_allocator.hpp"
+
+namespace vk {
+
+VmaAllocator create_allocator(VkInstance instance,
+                              VkPhysicalDevice physical_device,
+                              VkDevice device) {
+  VmaAllocatorCreateInfo create_info{};
+  create_info.instance = instance;
+  create_info.physicalDevice = physical_device;
+  create_info.device = device;
+  VmaAllocator allocator{};
+  vmaCreateAllocator(&create_info, &allocator);
+  return allocator;
+}
+
+AllocatedBuffer create_buffer(VmaAllocator allocator, VkDeviceSize size,
+                              VkBufferUsageFlags usage,
+                              VmaMemoryUsage memory_usage) {
+  VkBufferCreateInfo buffer_info{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+  buffer_info.size = size;
+  buffer_info.usage = usage;
+  buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+  VmaAllocationCreateInfo alloc_info{};
+  alloc_info.usage = memory_usage;
+
+  AllocatedBuffer result{};
+  vmaCreateBuffer(allocator, &buffer_info, &alloc_info, &result.buffer,
+                  &result.allocation, nullptr);
+  return result;
+}
+
+void destroy_buffer(VmaAllocator allocator, AllocatedBuffer &buffer) {
+  if (buffer.buffer != VK_NULL_HANDLE && buffer.allocation != VK_NULL_HANDLE) {
+    vmaDestroyBuffer(allocator, buffer.buffer, buffer.allocation);
+    buffer.buffer = VK_NULL_HANDLE;
+    buffer.allocation = VK_NULL_HANDLE;
+  }
+}
+
+void destroy_allocator(VmaAllocator allocator) {
+  if (allocator) {
+    vmaDestroyAllocator(allocator);
+  }
+}
+
+} // namespace vk

--- a/src/vk/vma_allocator.hpp
+++ b/src/vk/vma_allocator.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vk_mem_alloc.h>
+#include <vulkan/vulkan.h>
+
+namespace vk {
+
+struct AllocatedBuffer {
+  VkBuffer buffer{VK_NULL_HANDLE};
+  VmaAllocation allocation{};
+};
+
+VmaAllocator create_allocator(VkInstance instance,
+                              VkPhysicalDevice physical_device,
+                              VkDevice device);
+AllocatedBuffer create_buffer(VmaAllocator allocator, VkDeviceSize size,
+                              VkBufferUsageFlags usage,
+                              VmaMemoryUsage memory_usage);
+void destroy_buffer(VmaAllocator allocator, AllocatedBuffer &buffer);
+void destroy_allocator(VmaAllocator allocator);
+
+} // namespace vk

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add Vulkan Memory Allocator via FetchContent and link to Vulkan targets
- provide `vk::AllocatedBuffer` helpers backed by VMA
- clean corrupted lint/type/test configs to restore project checks

## Testing
- `pytest -q`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d409e50832d9d2b35513369a36e