### PR TITLE
Add VMA allocation helpers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,8 +174,12 @@ if(TARGET VoxelVK_Elite_ALL)
 endif()
 
 
+# --- Vulkan allocation helpers ---
+if(TARGET VoxelVK_Elite_ALL)
+  target_sources(VoxelVK_Elite_ALL PRIVATE src/vk/alloc_helpers.cpp)
+endif()
+
 # --- Voxel SAT compute dispatch ---
 if(TARGET VoxelVK_Elite_ALL)
   # target_sources(VoxelVK_Elite_ALL PRIVATE src/render/voxelize_sat.cpp) # Removed duplicate registration
 endif()
-        main

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,52 +1,6 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
@@ -56,47 +10,7 @@ module.exports = [
       globals: { ...globals.node, ...globals.es2021 }
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
       '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -107,127 +21,11 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
-      'scripts/**',
-    ],
-
-
       'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
   }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
 exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/src/vk/alloc_helpers.cpp
+++ b/src/vk/alloc_helpers.cpp
@@ -1,0 +1,65 @@
+#include "alloc_helpers.hpp"
+
+namespace vkx {
+
+AllocatedBuffer create_staging_buffer(VmaAllocator allocator,
+                                      VkDeviceSize size,
+                                      VkBufferUsageFlags usage) {
+    AllocatedBuffer out{};
+
+    VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bci.size = size;
+    bci.usage = usage;
+    bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO;
+    aci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+                VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VmaAllocationInfo info{};
+    if (vmaCreateBuffer(allocator, &bci, &aci, &out.buffer, &out.allocation, &info) == VK_SUCCESS) {
+        out.mapped = info.pMappedData;
+    }
+    return out;
+}
+
+AllocatedBuffer create_readback_buffer(VmaAllocator allocator,
+                                       VkDeviceSize size,
+                                       VkBufferUsageFlags usage) {
+    AllocatedBuffer out{};
+
+    VkBufferCreateInfo bci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bci.size = size;
+    bci.usage = usage;
+    bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO;
+    aci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT |
+                VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VmaAllocationInfo info{};
+    if (vmaCreateBuffer(allocator, &bci, &aci, &out.buffer, &out.allocation, &info) == VK_SUCCESS) {
+        out.mapped = info.pMappedData;
+    }
+    return out;
+}
+
+VmaPool create_transient_pool(VmaAllocator allocator,
+                              uint32_t memoryTypeIndex,
+                              VkDeviceSize blockSize,
+                              size_t maxBlockCount) {
+    VmaPoolCreateInfo pci{};
+    pci.memoryTypeIndex = memoryTypeIndex;
+    pci.blockSize = blockSize;
+    pci.maxBlockCount = maxBlockCount;
+    pci.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT |
+                VMA_POOL_CREATE_IGNORE_BUFFER_IMAGE_GRANULARITY_BIT;
+
+    VmaPool pool = VK_NULL_HANDLE;
+    vmaCreatePool(allocator, &pci, &pool);
+    return pool;
+}
+
+} // namespace vkx

--- a/src/vk/alloc_helpers.hpp
+++ b/src/vk/alloc_helpers.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
+
+namespace vkx {
+
+struct AllocatedBuffer {
+    VkBuffer     buffer = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
+    void*        mapped = nullptr;
+};
+
+// Creates a host-visible buffer intended for uploading data to the GPU.
+AllocatedBuffer create_staging_buffer(VmaAllocator allocator,
+                                      VkDeviceSize size,
+                                      VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+// Creates a host-visible buffer intended for reading data back from the GPU.
+AllocatedBuffer create_readback_buffer(VmaAllocator allocator,
+                                       VkDeviceSize size,
+                                       VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+
+// Creates a transient allocation pool backed by VMA.
+VmaPool create_transient_pool(VmaAllocator allocator,
+                              uint32_t memoryTypeIndex,
+                              VkDeviceSize blockSize = 0,
+                              size_t maxBlockCount = 0);
+
+// Helper for destroying a buffer created with the above helpers.
+inline void destroy_buffer(VmaAllocator allocator, const AllocatedBuffer& buf) {
+    if (buf.buffer != VK_NULL_HANDLE) {
+        vmaDestroyBuffer(allocator, buf.buffer, buf.allocation);
+    }
+}
+
+inline void destroy_pool(VmaAllocator allocator, VmaPool pool) {
+    if (pool) {
+        vmaDestroyPool(allocator, pool);
+    }
+}
+
+} // namespace vkx

--- a/tests/test_capsule_properties.py
+++ b/tests/test_capsule_properties.py
@@ -1,19 +1,11 @@
 import pytest
 
-
-pytest.skip(
-    "capsule tests require native capsule module; skipped in CI",
-    allow_module_level=True,
-)
-
-from src.physics.capsule import Capsule
-
 np = pytest.importorskip("numpy")
 try:  # Skip tests if the capsule module is unavailable or invalid.
     from src.physics.capsule import Capsule
 except (ImportError, ModuleNotFoundError):  # pragma: no cover - skip if module import fails
     pytest.skip("capsule module unavailable", allow_module_level=True)
-        main
+
 
 def test_seg_properties():
     cap = Capsule(

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add VMA helpers for staging, readback, and transient allocations
- wire alloc helpers into build
- clean up test and lint/type-check configs

## Testing
- `pytest`
- `npx eslint .`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a42d428e18832da7f3573c738d354f