### PR TITLE
docs: remove outdated Node linting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,6 @@ Run the test suite:
 pytest
 ```
 
-```
-
-## Linting
-To check JavaScript or TypeScript sources, run:
-```bash
-npx eslint .
-
-
-
-
 ## Samples
 
 ### demo_window


### PR DESCRIPTION
## Summary
- remove Node.js linting instructions from README that referenced a non-existent script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68a42d4da9e8832da4812171208289b8