### PR TITLE
Add resource manager for Vulkan render resources

### DIFF
--- a/apps/demo_window.cpp
+++ b/apps/demo_window.cpp
@@ -3,12 +3,19 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
+#include "../src/render/resource_manager.hpp"
+
+static bool framebufferResized = false;
 
 int main() {
     if (!glfwInit()) return 1;
     glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
     GLFWwindow* window = glfwCreateWindow(800, 600, "demo_window", nullptr, nullptr);
     if (!window) { glfwTerminate(); return 1; }
+    glfwSetFramebufferSizeCallback(window, [](GLFWwindow*, int, int){
+        framebufferResized = true;
+        voxelvk::gResourceManager.onSwapchainResize();
+    });
 
     // Instance
     std::vector<const char*> layers;
@@ -66,6 +73,7 @@ int main() {
     dci.enabledExtensionCount = 1; dci.ppEnabledExtensionNames = devExts;
     VkDevice device;
     if(vkCreateDevice(gpu,&dci,nullptr,&device)!=VK_SUCCESS){ std::cerr<<"vkCreateDevice failed\n"; return 6; }
+    voxelvk::gResourceManager.init(device, nullptr, 2);
     VkQueue queue; vkGetDeviceQueue(device,graphicsQueue,0,&queue);
 
     // Swapchain
@@ -137,6 +145,10 @@ int main() {
 
     while(!glfwWindowShouldClose(window)){
         glfwPollEvents();
+        if(framebufferResized){
+            framebufferResized = false;
+            // In a real engine we would recreate swapchain resources here
+        }
         uint32_t imgIndex; vkAcquireNextImageKHR(device,swapchain,UINT64_MAX,imgAvailable,VK_NULL_HANDLE,&imgIndex);
         VkPipelineStageFlags waitStage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
         VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO};
@@ -159,6 +171,7 @@ int main() {
     vkDestroyRenderPass(device,rp,nullptr);
     for(auto v:views) vkDestroyImageView(device,v,nullptr);
     vkDestroySwapchainKHR(device,swapchain,nullptr);
+    voxelvk::gResourceManager.shutdown();
     vkDestroyDevice(device,nullptr);
     vkDestroySurfaceKHR(instance,surface,nullptr);
     vkDestroyInstance(instance,nullptr);

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,104 +1,17 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
       '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
-      'build_ci_sanity/**',
       'cmake/**',
       'docs/**',
       'assets/**',
@@ -107,127 +20,7 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
       'scripts/**',
     ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
-    },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
 exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+ignore_missing_imports = True

--- a/src/render/csm_layout.cpp
+++ b/src/render/csm_layout.cpp
@@ -1,5 +1,6 @@
 
 #include "csm_layout.hpp"
+#include "resource_manager.hpp"
 #include <vector>
 
 namespace voxelvk {
@@ -11,7 +12,7 @@ bool create_csm_set(VkDevice device, uint32_t binding, CSMSet& out)
     VkDescriptorSetLayoutCreateInfo lci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
     lci.bindingCount = 1;
     lci.pBindings = &b;
-    if (vkCreateDescriptorSetLayout(device, &lci, nullptr, &out.layout) != VK_SUCCESS) return false;
+    if (gResourceManager.createDescriptorSetLayout(&lci, &out.layout) != VK_SUCCESS) return false;
 
     // pool
     VkDescriptorPoolSize ps{};
@@ -22,7 +23,7 @@ bool create_csm_set(VkDevice device, uint32_t binding, CSMSet& out)
     pci.maxSets = 1;
     pci.poolSizeCount = 1;
     pci.pPoolSizes = &ps;
-    if (vkCreateDescriptorPool(device, &pci, nullptr, &out.pool) != VK_SUCCESS) return false;
+    if (gResourceManager.createDescriptorPool(&pci, &out.pool) != VK_SUCCESS) return false;
 
     // allocate
     VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};

--- a/src/render/csm_pass.cpp
+++ b/src/render/csm_pass.cpp
@@ -1,6 +1,7 @@
 
 #include "csm_pass.hpp"
 #include "csm_descriptor.hpp"
+#include "resource_manager.hpp"
 #include <stdexcept>
 #include <cstring>
 
@@ -9,7 +10,7 @@
 
 namespace voxelvk {
 
-static VkShaderModule loadShader(VkDevice dev, const char* path);
+static VkShaderModule loadShader(VkDevice /*dev*/, const char* path);
 
 uint32_t CSMShadowPass::findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags){
     VkPhysicalDeviceMemoryProperties memProps{};
@@ -68,7 +69,7 @@ bool CSMShadowPass::createDepthArray(VkPhysicalDevice phys){
     vci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
     vci.subresourceRange.levelCount = 1;
     vci.subresourceRange.layerCount = cascades;
-    if(vkCreateImageView(device, &vci, nullptr, &depthArrayView) != VK_SUCCESS) return false;
+    if(gResourceManager.createImageView(&vci, &depthArrayView) != VK_SUCCESS) return false;
 
     // Per-layer views for rendering
     layerViews.resize(cascades);
@@ -77,7 +78,7 @@ bool CSMShadowPass::createDepthArray(VkPhysicalDevice phys){
         lv.viewType = VK_IMAGE_VIEW_TYPE_2D;
         lv.subresourceRange.baseArrayLayer = i;
         lv.subresourceRange.layerCount = 1;
-        if(vkCreateImageView(device, &lv, nullptr, &layerViews[i]) != VK_SUCCESS) return false;
+        if(gResourceManager.createImageView(&lv, &layerViews[i]) != VK_SUCCESS) return false;
     }
     return true;
 }
@@ -90,7 +91,7 @@ bool CSMShadowPass::createSampler(){
     si.addressModeU = si.addressModeV = si.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     si.compareEnable = VK_FALSE; // we sample as regular depth; PCSS manages compare
     si.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;
-    return vkCreateSampler(device, &si, nullptr, &depthSampler) == VK_SUCCESS;
+    return gResourceManager.createSampler(&si, &depthSampler) == VK_SUCCESS;
 }
 
 bool CSMShadowPass::createUBO(){
@@ -112,12 +113,12 @@ bool CSMShadowPass::createUBO(){
     b.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
     VkDescriptorSetLayoutCreateInfo lci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
     lci.bindingCount = 1; lci.pBindings = &b;
-    if(vkCreateDescriptorSetLayout(device, &lci, nullptr, &uboSetLayout) != VK_SUCCESS) return false;
+    if(gResourceManager.createDescriptorSetLayout(&lci, &uboSetLayout) != VK_SUCCESS) return false;
 
     VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER; ps.descriptorCount = 1;
     VkDescriptorPoolCreateInfo pci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
     pci.maxSets = 1; pci.poolSizeCount = 1; pci.pPoolSizes = &ps;
-    if(vkCreateDescriptorPool(device, &pci, nullptr, &descPool) != VK_SUCCESS) return false;
+    if(gResourceManager.createDescriptorPool(&pci, &descPool) != VK_SUCCESS) return false;
 
     VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
     ai.descriptorPool = descPool; ai.descriptorSetCount = 1; ai.pSetLayouts = &uboSetLayout;
@@ -183,7 +184,7 @@ bool CSMShadowPass::createPipeline(VkPhysicalDevice /*phys*/){
     VkPipelineLayoutCreateInfo lci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
     lci.setLayoutCount = 1; lci.pSetLayouts = &uboSetLayout;
     lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &pcr;
-    if(vkCreatePipelineLayout(device, &lci, nullptr, &pipelineLayout) != VK_SUCCESS) return false;
+    if(gResourceManager.createPipelineLayout(&lci, &pipelineLayout) != VK_SUCCESS) return false;
 
     VkDynamicState dynStatesArr[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR, VK_DYNAMIC_STATE_DEPTH_BIAS };
     VkPipelineDynamicStateCreateInfo dyn{VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
@@ -204,7 +205,7 @@ bool CSMShadowPass::createPipeline(VkPhysicalDevice /*phys*/){
     pci.renderPass = VK_NULL_HANDLE;
     pci.subpass = 0;
 
-    if(vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pci, nullptr, &pipeline) != VK_SUCCESS) return false;
+    if(gResourceManager.createGraphicsPipeline(&pci, &pipeline) != VK_SUCCESS) return false;
 
     vkDestroyShaderModule(device, vs, nullptr);
     vkDestroyShaderModule(device, fs, nullptr);
@@ -275,14 +276,14 @@ static std::vector<char> readFile(const char* path){
     std::fclose(f);
     return data;
 }
-static VkShaderModule loadShader(VkDevice dev, const char* path){
+static VkShaderModule loadShader(VkDevice /*dev*/, const char* path){
     auto bytes = readFile(path);
     if(bytes.empty()) return VK_NULL_HANDLE;
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     ci.codeSize = bytes.size();
     ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());
-    VkShaderModule m; 
-    if(vkCreateShaderModule(dev, &ci, nullptr, &m) != VK_SUCCESS) return VK_NULL_HANDLE;
+    VkShaderModule m;
+    if(gResourceManager.createShaderModule(&ci, &m) != VK_SUCCESS) return VK_NULL_HANDLE;
     return m;
 }
 

--- a/src/render/ibl_brdf.cpp
+++ b/src/render/ibl_brdf.cpp
@@ -1,5 +1,6 @@
 
 #include "ibl_brdf.hpp"
+#include "resource_manager.hpp"
 #include <vector>
 #include <cassert>
 #include <cstring>
@@ -17,7 +18,7 @@ static uint32_t FindMemoryType(VkPhysicalDevice phys, uint32_t typeFilter, VkMem
     return ~0u;
 }
 
-static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path) {
+static VkShaderModule LoadShaderModuleFromFile(VkDevice /*device*/, const char* path) {
     FILE* f = fopen(path, "rb");
     if (!f) return VK_NULL_HANDLE;
     fseek(f, 0, SEEK_END);
@@ -30,7 +31,7 @@ static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path
     ci.codeSize = buf.size()*4;
     ci.pCode = buf.data();
     VkShaderModule mod = VK_NULL_HANDLE;
-    if (vkCreateShaderModule(device, &ci, nullptr, &mod) != VK_SUCCESS) return VK_NULL_HANDLE;
+    if (gResourceManager.createShaderModule(&ci, &mod) != VK_SUCCESS) return VK_NULL_HANDLE;
     return mod;
 }
 
@@ -71,7 +72,7 @@ bool CreateBRDFLUT(VkDevice device,
     iv.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     iv.subresourceRange.levelCount = 1;
     iv.subresourceRange.layerCount = 1;
-    if (vkCreateImageView(device, &iv, nullptr, &out.view) != VK_SUCCESS) {
+    if (gResourceManager.createImageView(&iv, &out.view) != VK_SUCCESS) {
         return false;
     }
 
@@ -83,7 +84,7 @@ bool CreateBRDFLUT(VkDevice device,
     sci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     sci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     sci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    if (vkCreateSampler(device, &sci, nullptr, &out.sampler) != VK_SUCCESS) {
+    if (gResourceManager.createSampler(&sci, &out.sampler) != VK_SUCCESS) {
         return false;
     }
 
@@ -98,21 +99,21 @@ bool CreateBRDFLUT(VkDevice device,
     dslci.bindingCount = 1;
     dslci.pBindings = &b;
     VkDescriptorSetLayout dsl = VK_NULL_HANDLE;
-    if (vkCreateDescriptorSetLayout(device, &dslci, nullptr, &dsl) != VK_SUCCESS) return false;
+    if (gResourceManager.createDescriptorSetLayout(&dslci, &dsl) != VK_SUCCESS) return false;
 
     // Pipeline layout
     VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
     plci.setLayoutCount = 1;
     plci.pSetLayouts = &dsl;
     VkPipelineLayout pl = VK_NULL_HANDLE;
-    if (vkCreatePipelineLayout(device, &plci, nullptr, &pl) != VK_SUCCESS) return false;
+    if (gResourceManager.createPipelineLayout(&plci, &pl) != VK_SUCCESS) return false;
 
     // Descriptor pool / set
     VkDescriptorPoolSize poolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1 };
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
     dpci.maxSets = 1; dpci.poolSizeCount = 1; dpci.pPoolSizes = &poolSize;
     VkDescriptorPool pool = VK_NULL_HANDLE;
-    if (vkCreateDescriptorPool(device, &dpci, nullptr, &pool) != VK_SUCCESS) return false;
+    if (gResourceManager.createDescriptorPool(&dpci, &pool) != VK_SUCCESS) return false;
 
     VkDescriptorSetAllocateInfo dsai{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO };
     dsai.descriptorPool = pool; dsai.descriptorSetCount = 1; dsai.pSetLayouts = &dsl;
@@ -146,7 +147,7 @@ bool CreateBRDFLUT(VkDevice device,
     cpci.stage = s;
     cpci.layout = pl;
     VkPipeline pipe = VK_NULL_HANDLE;
-    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipe) != VK_SUCCESS) {
+    if (gResourceManager.createComputePipeline(&cpci, &pipe) != VK_SUCCESS) {
         vkDestroyShaderModule(device, cs, nullptr);
         return false;
     }

--- a/src/render/resource_manager.cpp
+++ b/src/render/resource_manager.cpp
@@ -1,0 +1,131 @@
+#include "resource_manager.hpp"
+#include "vk_mem_alloc.h"
+
+namespace voxelvk {
+
+void ResourceManager::init(VkDevice dev, VmaAllocator alloc, uint32_t frames){
+    device = dev;
+    allocator = alloc;
+    frameCount = frames;
+    currentFrame = 0;
+    frameAllocs.resize(frames);
+}
+
+void ResourceManager::shutdown(){
+    for(auto& f : frameAllocs){
+        for(size_t i=0;i<f.buffers.size();++i){
+            if(f.buffers[i]){
+                vmaDestroyBuffer(allocator, f.buffers[i], f.allocs[i]);
+            }
+        }
+        f.buffers.clear();
+        f.allocs.clear();
+    }
+    frameAllocs.clear();
+    globalBuffers.clear();
+    globalImages.clear();
+    device = VK_NULL_HANDLE;
+    allocator = nullptr;
+}
+
+void ResourceManager::beginFrame(uint32_t frameIndex){
+    currentFrame = frameIndex % frameCount;
+    auto& f = frameAllocs[currentFrame];
+    for(size_t i=0;i<f.buffers.size();++i){
+        if(f.buffers[i]){
+            vmaDestroyBuffer(allocator, f.buffers[i], f.allocs[i]);
+        }
+    }
+    f.buffers.clear();
+    f.allocs.clear();
+}
+
+void ResourceManager::onSwapchainResize(){
+    for(auto& f : frameAllocs){
+        for(size_t i=0;i<f.buffers.size();++i){
+            if(f.buffers[i]){
+                vmaDestroyBuffer(allocator, f.buffers[i], f.allocs[i]);
+            }
+        }
+        f.buffers.clear();
+        f.allocs.clear();
+    }
+}
+
+VkResult ResourceManager::createShaderModule(const VkShaderModuleCreateInfo* ci, VkShaderModule* out) const{
+    return vkCreateShaderModule(device, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createDescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo* ci, VkDescriptorSetLayout* out) const{
+    return vkCreateDescriptorSetLayout(device, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createDescriptorPool(const VkDescriptorPoolCreateInfo* ci, VkDescriptorPool* out) const{
+    return vkCreateDescriptorPool(device, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createPipelineLayout(const VkPipelineLayoutCreateInfo* ci, VkPipelineLayout* out) const{
+    return vkCreatePipelineLayout(device, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createGraphicsPipeline(const VkGraphicsPipelineCreateInfo* ci, VkPipeline* out) const{
+    return vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createComputePipeline(const VkComputePipelineCreateInfo* ci, VkPipeline* out) const{
+    return vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createImageView(const VkImageViewCreateInfo* ci, VkImageView* out) const{
+    return vkCreateImageView(device, ci, nullptr, out);
+}
+
+VkResult ResourceManager::createSampler(const VkSamplerCreateInfo* ci, VkSampler* out) const{
+    return vkCreateSampler(device, ci, nullptr, out);
+}
+
+VkBuffer ResourceManager::createStagingBuffer(VkDeviceSize size, void** mapped, VmaAllocation* outAlloc){
+    VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bi.size = size;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    VmaAllocationCreateInfo aci{};
+    aci.usage = VMA_MEMORY_USAGE_AUTO;
+    aci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT |
+               VMA_ALLOCATION_CREATE_MAPPED_BIT;
+    VmaAllocationInfo info{};
+    VkBuffer buf;
+    if(vmaCreateBuffer(allocator, &bi, &aci, &buf, outAlloc, &info) != VK_SUCCESS)
+        return VK_NULL_HANDLE;
+    if(mapped) *mapped = info.pMappedData;
+    auto& f = frameAllocs[currentFrame];
+    f.buffers.push_back(buf);
+    f.allocs.push_back(*outAlloc);
+    return buf;
+}
+
+void ResourceManager::destroyStagingBuffer(VkBuffer buf, VmaAllocation alloc){
+    if(buf) vmaDestroyBuffer(allocator, buf, alloc);
+}
+
+void ResourceManager::registerBuffer(const std::string& name, VkBuffer buf){
+    globalBuffers[name] = buf;
+}
+
+VkBuffer ResourceManager::getBuffer(const std::string& name) const{
+    auto it = globalBuffers.find(name);
+    return it == globalBuffers.end() ? VK_NULL_HANDLE : it->second;
+}
+
+void ResourceManager::registerImage(const std::string& name, VkImage img){
+    globalImages[name] = img;
+}
+
+VkImage ResourceManager::getImage(const std::string& name) const{
+    auto it = globalImages.find(name);
+    return it == globalImages.end() ? VK_NULL_HANDLE : it->second;
+}
+
+ResourceManager gResourceManager;
+
+} // namespace voxelvk
+

--- a/src/render/resource_manager.hpp
+++ b/src/render/resource_manager.hpp
@@ -1,0 +1,66 @@
+#pragma once
+#include <vulkan/vulkan.h>
+#include <unordered_map>
+#include <string>
+#include <vector>
+
+// Forward-declare VMA types
+struct VmaAllocator_T;
+using VmaAllocator = VmaAllocator_T*;
+struct VmaAllocation_T;
+using VmaAllocation = VmaAllocation_T*;
+
+namespace voxelvk {
+
+class ResourceManager {
+public:
+    ResourceManager() = default;
+
+    void init(VkDevice dev, VmaAllocator alloc, uint32_t frames);
+    void shutdown();
+    void beginFrame(uint32_t frameIndex);
+    void onSwapchainResize();
+
+    // Wrappers around Vulkan allocation calls
+    VkResult createShaderModule(const VkShaderModuleCreateInfo* ci, VkShaderModule* out) const;
+    VkResult createDescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo* ci, VkDescriptorSetLayout* out) const;
+    VkResult createDescriptorPool(const VkDescriptorPoolCreateInfo* ci, VkDescriptorPool* out) const;
+    VkResult createPipelineLayout(const VkPipelineLayoutCreateInfo* ci, VkPipelineLayout* out) const;
+    VkResult createGraphicsPipeline(const VkGraphicsPipelineCreateInfo* ci, VkPipeline* out) const;
+    VkResult createComputePipeline(const VkComputePipelineCreateInfo* ci, VkPipeline* out) const;
+    VkResult createImageView(const VkImageViewCreateInfo* ci, VkImageView* out) const;
+    VkResult createSampler(const VkSamplerCreateInfo* ci, VkSampler* out) const;
+
+    // Staging helpers
+    VkBuffer createStagingBuffer(VkDeviceSize size, void** mapped, VmaAllocation* outAlloc);
+    void destroyStagingBuffer(VkBuffer buf, VmaAllocation alloc);
+
+    // Global resource registry
+    void registerBuffer(const std::string& name, VkBuffer buf);
+    VkBuffer getBuffer(const std::string& name) const;
+    void registerImage(const std::string& name, VkImage img);
+    VkImage getImage(const std::string& name) const;
+
+    VkDevice getDevice() const { return device; }
+    VmaAllocator getAllocator() const { return allocator; }
+
+private:
+    VkDevice device{VK_NULL_HANDLE};
+    VmaAllocator allocator{nullptr};
+    uint32_t frameCount{0};
+    uint32_t currentFrame{0};
+
+    struct FrameAlloc {
+        std::vector<VkBuffer> buffers;
+        std::vector<VmaAllocation> allocs;
+    };
+    std::vector<FrameAlloc> frameAllocs;
+
+    std::unordered_map<std::string, VkBuffer> globalBuffers;
+    std::unordered_map<std::string, VkImage> globalImages;
+};
+
+extern ResourceManager gResourceManager;
+
+} // namespace voxelvk
+

--- a/src/render/sdf_generator.cpp
+++ b/src/render/sdf_generator.cpp
@@ -1,9 +1,10 @@
 #include "sdf_generator.hpp"
+#include "resource_manager.hpp"
 #include <vector>
 #include <algorithm>
 #include <cstring>
 namespace voxelvk {
-static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path){
+static VkShaderModule LoadShaderModuleFromFile(VkDevice /*device*/, const char* path){
     FILE* f = fopen(path, "rb");
     if(!f) return VK_NULL_HANDLE;
     fseek(f, 0, SEEK_END);
@@ -24,7 +25,7 @@ static VkShaderModule LoadShaderModuleFromFile(VkDevice device, const char* path
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     ci.codeSize = buf.size()*4; ci.pCode = buf.data();
     VkShaderModule mod = VK_NULL_HANDLE;
-    if(vkCreateShaderModule(device,&ci,nullptr,&mod)!=VK_SUCCESS) {
+    if(gResourceManager.createShaderModule(&ci,&mod)!=VK_SUCCESS) {
         fprintf(stderr, "Error: Failed to create shader module from file '%s'\n", path);
         return VK_NULL_HANDLE;
     }
@@ -55,15 +56,15 @@ bool GenerateSDF(VkDevice device,
     VkImageViewCreateInfo ivci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
     ivci.image=out.image; ivci.viewType=VK_IMAGE_VIEW_TYPE_3D; ivci.format=out.format;
     ivci.subresourceRange.aspectMask=VK_IMAGE_ASPECT_COLOR_BIT; ivci.subresourceRange.levelCount=1; ivci.subresourceRange.layerCount=1;
-    if(vkCreateImageView(device,&ivci,nullptr,&out.view)!=VK_SUCCESS) return false;
+    if(gResourceManager.createImageView(&ivci,&out.view)!=VK_SUCCESS) return false;
     // Temp ping/pong images (RGBA16F)
     VkImageCreateInfo tmpImg = img; tmpImg.format = VK_FORMAT_R16G16B16A16_SFLOAT;
     VkImage tmpA, tmpB; VmaAllocation tmpAAlloc, tmpBAlloc; VkImageView tmpAView, tmpBView;
     if(vmaCreateImage(allocator,&tmpImg,&aci,&tmpA,&tmpAAlloc,nullptr)!=VK_SUCCESS) return false;
     if(vmaCreateImage(allocator,&tmpImg,&aci,&tmpB,&tmpBAlloc,nullptr)!=VK_SUCCESS) return false;
     ivci.image=tmpA; ivci.viewType=VK_IMAGE_VIEW_TYPE_3D; ivci.format=VK_FORMAT_R16G16B16A16_SFLOAT;
-    if(vkCreateImageView(device,&ivci,nullptr,&tmpAView)!=VK_SUCCESS) return false;
-    ivci.image=tmpB; if(vkCreateImageView(device,&ivci,nullptr,&tmpBView)!=VK_SUCCESS) return false;
+    if(gResourceManager.createImageView(&ivci,&tmpAView)!=VK_SUCCESS) return false;
+    ivci.image=tmpB; if(gResourceManager.createImageView(&ivci,&tmpBView)!=VK_SUCCESS) return false;
     // Descriptor set layout
     VkDescriptorSetLayoutBinding binds[2]{};
     binds[0].binding=0; binds[0].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; binds[0].descriptorCount=1; binds[0].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT;
@@ -72,15 +73,15 @@ bool GenerateSDF(VkDevice device,
     dslci.bindingCount = 2;
     dslci.pBindings = binds;
     VkDescriptorSetLayout dsl;
-    if (vkCreateDescriptorSetLayout(device, &dslci, nullptr, &dsl) != VK_SUCCESS)
+    if (gResourceManager.createDescriptorSetLayout(&dslci, &dsl) != VK_SUCCESS)
         return false;
     VkPushConstantRange pcr{VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(int)*2};
     VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
     plci.setLayoutCount=1; plci.pSetLayouts=&dsl; plci.pushConstantRangeCount=1; plci.pPushConstantRanges=&pcr;
-    VkPipelineLayout pl; if(vkCreatePipelineLayout(device,&plci,nullptr,&pl)!=VK_SUCCESS) return false;
+    VkPipelineLayout pl; if(gResourceManager.createPipelineLayout(&plci,&pl)!=VK_SUCCESS) return false;
     VkDescriptorPoolSize dps{VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,2};
     VkDescriptorPoolCreateInfo dpci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO}; dpci.maxSets=1; dpci.poolSizeCount=1; dpci.pPoolSizes=&dps;
-    VkDescriptorPool pool; if(vkCreateDescriptorPool(device,&dpci,nullptr,&pool)!=VK_SUCCESS) return false;
+    VkDescriptorPool pool; if(gResourceManager.createDescriptorPool(&dpci,&pool)!=VK_SUCCESS) return false;
     VkDescriptorSetAllocateInfo dsai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
     dsai.descriptorPool = pool;
     dsai.descriptorSetCount = 1;
@@ -106,7 +107,7 @@ bool GenerateSDF(VkDevice device,
     cpci.stage = ss;
     cpci.layout = pl;
     VkPipeline pipe;
-    if (vkCreateComputePipelines(device, VK_NULL_HANDLE, 1, &cpci, nullptr, &pipe) != VK_SUCCESS) {
+    if (gResourceManager.createComputePipeline(&cpci, &pipe) != VK_SUCCESS) {
         vkDestroyShaderModule(device, cs, nullptr);
         return false;
     }

--- a/src/render/sky_pass.cpp
+++ b/src/render/sky_pass.cpp
@@ -1,4 +1,5 @@
 #include "sky_pass.hpp"
+#include "resource_manager.hpp"
 #include <vector>
 #include <cstdio>
 #include <cstring>
@@ -21,14 +22,14 @@ static std::vector<char> readFile(const char* path){
     return data;
 }
 
-static VkShaderModule loadShader(VkDevice dev, const char* path){
+static VkShaderModule loadShader(VkDevice /*dev*/, const char* path){
     auto bytes = readFile(path);
     if(bytes.empty()) return VK_NULL_HANDLE;
     VkShaderModuleCreateInfo ci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
     ci.codeSize = bytes.size();
     ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());
     VkShaderModule m;
-    if(vkCreateShaderModule(dev,&ci,nullptr,&m)!=VK_SUCCESS) return VK_NULL_HANDLE;
+    if(gResourceManager.createShaderModule(&ci,&m)!=VK_SUCCESS) return VK_NULL_HANDLE;
     return m;
 }
 
@@ -42,7 +43,7 @@ bool SkyPass::init(VkPhysicalDevice /*phys*/, VkDevice dev, VkFormat colorFormat
     b.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
     VkDescriptorSetLayoutCreateInfo lci{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO};
     lci.bindingCount = 1; lci.pBindings = &b;
-    if(vkCreateDescriptorSetLayout(device,&lci,nullptr,&noiseSetLayout)!=VK_SUCCESS) return false;
+    if(gResourceManager.createDescriptorSetLayout(&lci,&noiseSetLayout)!=VK_SUCCESS) return false;
 
     VkPushConstantRange pcr{};
     pcr.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -51,7 +52,7 @@ bool SkyPass::init(VkPhysicalDevice /*phys*/, VkDevice dev, VkFormat colorFormat
     VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
     plci.setLayoutCount = 1; plci.pSetLayouts = &noiseSetLayout;
     plci.pushConstantRangeCount = 1; plci.pPushConstantRanges = &pcr;
-    if(vkCreatePipelineLayout(device,&plci,nullptr,&pipelineLayout)!=VK_SUCCESS) return false;
+    if(gResourceManager.createPipelineLayout(&plci,&pipelineLayout)!=VK_SUCCESS) return false;
 
     VkShaderModule vs = loadShader(device, "spv/common/fullscreen.vert.spv");
     VkShaderModule fsSky = loadShader(device, "spv/post/atmosphere.frag.spv");
@@ -123,7 +124,7 @@ bool SkyPass::init(VkPhysicalDevice /*phys*/, VkDevice dev, VkFormat colorFormat
     pci.pColorBlendState = &cb;
     pci.pDynamicState = &dyn;
     pci.layout = pipelineLayout;
-    if(vkCreateGraphicsPipelines(device,nullptr,1,&pci,nullptr,&skyPipeline)!=VK_SUCCESS) return false;
+    if(gResourceManager.createGraphicsPipeline(&pci,&skyPipeline)!=VK_SUCCESS) return false;
 
     // Clouds pipeline with alpha blend
     stages[1].module = fsCloud;
@@ -134,7 +135,7 @@ bool SkyPass::init(VkPhysicalDevice /*phys*/, VkDevice dev, VkFormat colorFormat
     att.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
     att.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     att.alphaBlendOp = VK_BLEND_OP_ADD;
-    if(vkCreateGraphicsPipelines(device,nullptr,1,&pci,nullptr,&cloudPipeline)!=VK_SUCCESS) return false;
+    if(gResourceManager.createGraphicsPipeline(&pci,&cloudPipeline)!=VK_SUCCESS) return false;
 
     vkDestroyShaderModule(device, fsCloud, nullptr);
     vkDestroyShaderModule(device, fsSky, nullptr);

--- a/src/render/voxel_fill.cpp
+++ b/src/render/voxel_fill.cpp
@@ -1,4 +1,5 @@
 #include "voxel_fill.hpp"
+#include "resource_manager.hpp"
 #include <vector>
 #include <cstdio>
 
@@ -34,29 +35,27 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     }
     VkDescriptorSetLayoutCreateInfo dsl{ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO };
     dsl.bindingCount = 2; dsl.pBindings = b;
-    VkResult res = vkCreateDescriptorSetLayout(device, &dsl, nullptr, &m_dset_layout);
+    VkResult res = gResourceManager.createDescriptorSetLayout(&dsl, &m_dset_layout);
     if (res != VK_SUCCESS) return false;
 
     VkPipelineLayoutCreateInfo plci{ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO };
     plci.setLayoutCount = 1; plci.pSetLayouts = &m_dset_layout;
-    VkResult pl_result = vkCreatePipelineLayout(device, &plci, nullptr, &m_pipe_layout);
+    VkResult pl_result = gResourceManager.createPipelineLayout(&plci, &m_pipe_layout);
     if (pl_result != VK_SUCCESS) return false;
 
     auto spirv = load_spirv_file("spv/voxel_fill.comp.spv");
     if (spirv.empty()) return false;
     VkShaderModuleCreateInfo smci{ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO };
     smci.codeSize = spirv.size() * 4; smci.pCode = spirv.data();
-    VkShaderModule sm; vkCreateShaderModule(device, &smci, nullptr, &sm);
     VkShaderModule sm;
-    VkResult sm_res = vkCreateShaderModule(device, &smci, nullptr, &sm);
+    VkResult sm_res = gResourceManager.createShaderModule(&smci, &sm);
     if (sm_res != VK_SUCCESS) return false;
     VkComputePipelineCreateInfo cpci{ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO };
     cpci.stage = { VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO };
     cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
     cpci.stage.module = sm; cpci.stage.pName = "main";
     cpci.layout = m_pipe_layout;
-    vkCreateComputePipelines(device, cache, 1, &cpci, nullptr, &m_pipeline);
-    VkResult pipelineResult = vkCreateComputePipelines(device, cache, 1, &cpci, nullptr, &m_pipeline);
+    VkResult pipelineResult = gResourceManager.createComputePipeline(&cpci, &m_pipeline);
     vkDestroyShaderModule(device, sm, nullptr);
     if (pipelineResult != VK_SUCCESS) {
         return false;
@@ -66,7 +65,7 @@ bool VoxelFill::init(VkDevice device, VkPipelineCache cache) {
     VkDescriptorPoolCreateInfo dpci{ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO };
     dpci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
     dpci.maxSets = 1; dpci.poolSizeCount = 1; dpci.pPoolSizes = &ps;
-    VkResult poolResult = vkCreateDescriptorPool(device, &dpci, nullptr, &m_pool);
+    VkResult poolResult = gResourceManager.createDescriptorPool(&dpci, &m_pool);
     if (poolResult != VK_SUCCESS) return false;
     return true;
 }

--- a/src/render/voxelize_pass.cpp
+++ b/src/render/voxelize_pass.cpp
@@ -1,4 +1,5 @@
 #include "voxelize_pass.hpp"
+#include "resource_manager.hpp"
 #include <stdexcept>
 #include <vector>
 #include <cstdio>
@@ -7,7 +8,7 @@
 
 namespace voxelvk {
 
-static VkShaderModule loadShader(VkDevice dev, const char* path);
+static VkShaderModule loadShader(VkDevice /*dev*/, const char* path);
 
 uint32_t VoxelizePass::findMemoryType(VkPhysicalDevice phys, uint32_t typeBits, VkMemoryPropertyFlags flags){
     VkPhysicalDeviceMemoryProperties memProps{};
@@ -71,7 +72,7 @@ bool VoxelizePass::createImage(VkPhysicalDevice phys){
     vci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     vci.subresourceRange.levelCount = 1;
     vci.subresourceRange.layerCount = 1;
-    return vkCreateImageView(device, &vci, nullptr, &voxelView) == VK_SUCCESS;
+    return gResourceManager.createImageView(&vci, &voxelView) == VK_SUCCESS;
 }
 
 bool VoxelizePass::createDescriptors(){
@@ -87,7 +88,7 @@ bool VoxelizePass::createDescriptors(){
 
     lci.bindingCount = 1; lci.pBindings = &b;
         main
-    if(vkCreateDescriptorSetLayout(device, &lci, nullptr, &setLayout) != VK_SUCCESS) return false;
+    if(gResourceManager.createDescriptorSetLayout(&lci, &setLayout) != VK_SUCCESS) return false;
 
     VkDescriptorPoolSize ps{}; ps.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE; ps.descriptorCount = 1;
     VkDescriptorPoolCreateInfo pci{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
@@ -98,7 +99,7 @@ bool VoxelizePass::createDescriptors(){
 
     pci.maxSets = 1; pci.poolSizeCount = 1; pci.pPoolSizes = &ps;
         main
-    if(vkCreateDescriptorPool(device, &pci, nullptr, &descPool) != VK_SUCCESS) return false;
+    if(gResourceManager.createDescriptorPool(&pci, &descPool) != VK_SUCCESS) return false;
 
     VkDescriptorSetAllocateInfo ai{VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO};
     ai.descriptorPool = descPool; ai.descriptorSetCount = 1; ai.pSetLayouts = &setLayout;
@@ -178,7 +179,7 @@ bool VoxelizePass::createPipeline(VkPhysicalDevice phys){
     lci.setLayoutCount = 1; lci.pSetLayouts = &setLayout;
     lci.pushConstantRangeCount = 1; lci.pPushConstantRanges = &pcr;
         main
-    if(vkCreatePipelineLayout(device, &lci, nullptr, &pipelineLayout) != VK_SUCCESS){
+    if(gResourceManager.createPipelineLayout(&lci, &pipelineLayout) != VK_SUCCESS){
         vkDestroyShaderModule(device, vs, nullptr);
         vkDestroyShaderModule(device, fs, nullptr);
         return false;
@@ -208,7 +209,7 @@ bool VoxelizePass::createPipeline(VkPhysicalDevice phys){
     pci.renderPass = VK_NULL_HANDLE;
     pci.subpass = 0;
 
-    bool ok = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pci, nullptr, &pipeline) == VK_SUCCESS;
+    bool ok = gResourceManager.createGraphicsPipeline(&pci, &pipeline) == VK_SUCCESS;
     vkDestroyShaderModule(device, vs, nullptr);
     vkDestroyShaderModule(device, fs, nullptr);
     return ok;
@@ -259,7 +260,7 @@ static std::vector<char> readFile(const char* path){
     return data;
 }
 
-static VkShaderModule loadShader(VkDevice dev, const char* path){
+static VkShaderModule loadShader(VkDevice /*dev*/, const char* path){
     auto bytes = readFile(path);
 
     if(bytes.empty()) return VK_NULL_HANDLE;
@@ -273,7 +274,7 @@ static VkShaderModule loadShader(VkDevice dev, const char* path){
     ci.codeSize = bytes.size();
     ci.pCode = reinterpret_cast<const uint32_t*>(bytes.data());
     VkShaderModule m;
-    if(vkCreateShaderModule(dev, &ci, nullptr, &m) != VK_SUCCESS) return VK_NULL_HANDLE;
+    if(gResourceManager.createShaderModule(&ci, &m) != VK_SUCCESS) return VK_NULL_HANDLE;
     return m;
 }
 

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- add ResourceManager for Vulkan resource allocation and global registries
- route render passes through ResourceManager instead of raw vkCreate calls
- invoke ResourceManager on swapchain resize events in demo_window

## Testing
- `pytest`
- `npx eslint .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a42d57f140832d853265fcf2a2551e