### PR TITLE
docs: update sample target and shader path

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ npx eslint .
 
 ## Samples
 
-### demo_window
+### smoke_graphics_headless
 Build the sample:
 ```bash
 cmake -S . -B build
-cmake --build build --target demo_window
+cmake --build build --target smoke_graphics_headless
 ```
 Run it:
 ```bash
-./build/demo_window
+./build/smoke_graphics_headless
 ```
 
 ## World streaming and LOD

--- a/docs/CSM_TEXEL_SNAP_DEBUG.md
+++ b/docs/CSM_TEXEL_SNAP_DEBUG.md
@@ -16,7 +16,7 @@ u.mapTexelSize = 1.0f / float(shadowMapSize);
 
 ## Debug overlay in lighting shader
 ```glsl
-#include "shadows/csm_debug.glsl"
+#include "shaders_vk/shadows/csm_debug.glsl"
 
 // Blend a small tint to visualize cascades:
 bool ok;

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Quickstart Guide
 
-This guide walks you through cloning the repository, running basic smoke tests, and launching the demo viewer.
+This guide walks you through cloning the repository, running basic smoke tests, and executing a graphics sample.
 
 ## 1. Repository setup
 
@@ -36,13 +36,12 @@ For Python-based checks, run:
 pytest
 ```
 
-## 3. Launch the viewer
+## 3. Run graphics smoke sample
 
-Build and run the demo viewer:
-
+Build and run the headless graphics test:
 ```bash
-cmake --build build --target demo_window
-./build/demo_window
+cmake --build build --target smoke_graphics_headless
+./build/smoke_graphics_headless
 ```
 
-The window should appear rendering the sample scene.
+The run should complete without errors.


### PR DESCRIPTION
## Summary
- replace demo_window sample with smoke_graphics_headless in README and Quickstart
- fix shader include path in CSM texel snap doc
- confirm VoxelVK_Elite_ALL target exists

## Testing
- no tests run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68a42d4e891c832d9b4bc426cb83ef77