### PR TITLE
Remove stray chunk load async invocation

### DIFF
--- a/src/world/chunk_streamer.cpp
+++ b/src/world/chunk_streamer.cpp
@@ -44,7 +44,6 @@ void ChunkStreamer::Update(const glm::vec3& playerPos){
 }
 
 void ChunkStreamer::LoadChunkAsync(int id){
-    loading_[id] = std::async(std::launch::async, [id]{
     loading_[id] = std::async(std::launch::async, [this, id]{
         this->LoadChunk(id);
     });


### PR DESCRIPTION
## Summary
- fix `ChunkStreamer::LoadChunkAsync` to capture `this` and call `LoadChunk`

## Testing
- `cmake -S . -B build -G Ninja -DENABLE_IMGUI_OVERLAY=ON -DVOXELVK_ENABLE_CUDA=OFF -DVOXELVK_ENABLE_TENSORRT=OFF` *(fails: Parse error in CMakeLists.txt)*
- `g++ -std=c++20 -I src -c src/world/chunk_streamer.cpp` *(fails: missing macros and definitions)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `mypy` *(fails: duplicate option in mypy.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68a494b8f568832d919f56eb624157f1