### PR TITLE
docs: add world architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repo contains:
 - Self-contained smoke test + CTest
 - GitHub Actions CI (Linux & Windows) that installs Vulkan SDK, builds, tests, and publishes artifacts
 See [Quickstart guide](docs/QUICKSTART.md) for setup and usage.
+For an overview of chunk streaming, LOD, persistence, and AI palette integration, see [World Architecture overview](docs/WORLD_ARCHITECTURE.md).
 
 ## Local build
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -46,3 +46,5 @@ cmake --build build --target demo_window
 ```
 
 The window should appear rendering the sample scene.
+
+For an overview of chunk streaming, LOD, persistence, and AI palette integration, see [World Architecture overview](WORLD_ARCHITECTURE.md).

--- a/docs/WORLD_ARCHITECTURE.md
+++ b/docs/WORLD_ARCHITECTURE.md
@@ -1,0 +1,35 @@
+# World Architecture Overview
+
+This guide outlines how the engine streams and persists voxel data while integrating AI palettes. It is intended for contributors exploring the world and AI subsystems.
+
+## Chunk Streaming
+
+`ChunkStreamer` (`src/world/chunk_streamer.cpp`) loads voxel chunks around the player asynchronously. It monitors the player position, requests new chunks, and unloads distant ones to keep memory usage stable.
+
+```mermaid
+flowchart LR
+    Player -->|position| ChunkStreamer
+    ChunkStreamer -->|mesh requests| Mesher
+    ChunkStreamer -->|save| Persistence
+```
+
+## Level of Detail (LOD)
+
+`LodComponent` (`src/world/lod_component.cpp`) selects mesh detail based on distance. Thresholds are configured in [`world_lod.cfg`](../world_lod.cfg).
+
+## Persistence
+
+The `Persistence` module (`src/world/persistence.cpp`) serializes chunks to disk using run-length encoding and sparse voxel octrees. Utility scripts in `src/world/persistence.py` and `src/world/rle.py` aid inspection and conversion.
+
+## AI Palette Integration
+
+AI palettes translate semantic labels into voxel data. The bridge lives in `src/ai/ai_palette_to_mesher.cpp`, which feeds palette output to the mesher. Configuration helpers (`src/ai/ai_palette_config_io.cpp`) load palette definitions, while the ImGui panel (`src/ai/ai_imgui_palette_panel.cpp`) lets contributors experiment at runtime.
+
+```mermaid
+flowchart TD
+    AI_Palette -->|labels| Mesher
+    Mesher -->|chunks| ChunkStreamer
+    ChunkStreamer --> Persistence
+```
+
+For further exploration, see the `src/world/` and `src/ai/` directories.


### PR DESCRIPTION
## Summary
- document chunk streaming, LOD, persistence and AI palette integration in new `docs/WORLD_ARCHITECTURE.md`
- link world architecture guide from `README.md` and `docs/QUICKSTART.md`

## Testing
- no tests run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68a494c039cc832dad2cb1eb2f38cadc