### PR TITLE
refactor: simplify mypy config

### DIFF
--- a/docs/MYPY_EXCLUSIONS.md
+++ b/docs/MYPY_EXCLUSIONS.md
@@ -1,0 +1,11 @@
+# Type Checking Exclusions
+
+The project omits certain modules from static type checking to keep the
+build manageable:
+
+- `src/physics/` – physics routines are experimental and rely heavily on
+  dynamic numerical code that lacks annotations.
+- `tests/` and `tests/test_capsule_ground.py` – test modules include
+  rapid-prototype helpers and mock-heavy code that are not yet typed.
+
+These exclusions reduce mypy noise while annotations are added over time.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
+ignore_missing_imports = True
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+exclude = src/physics/|tests/|tests/test_capsule_ground.py


### PR DESCRIPTION
## Summary
- streamline mypy.ini into a single section and consolidate exclude patterns
- note why physics and test modules are skipped during type checking

## Testing
- `npx eslint --no-error-on-unmatched-pattern --config /tmp/eslint.config.js 'src/**/*.js'` *(warnings: ESLintEmptyConfigWarning)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a494d639a8832db66555e11c5b693e