### PR TITLE
Improve diff_voxelize build configurability and docs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
       '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -107,127 +21,11 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
       semi: ['error', 'always'],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,6 @@
 [mypy]
-ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
+ignore_missing_imports = True
 exclude = (?x)
     ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+    |tests/

--- a/src/ai/diff_voxelize.py
+++ b/src/ai/diff_voxelize.py
@@ -1,32 +1,68 @@
-"""Differentiable voxelization utilities with Python bindings."""
+"""Differentiable voxelization utilities with Python bindings.
+
+The module lazily builds a small C++ extension at import time using ``g++``
+with C++17 support. Two environment variables modify this behavior:
+
+``DIFF_VOXELIZE_LIB``
+    Absolute path to a prebuilt ``diff_voxelize`` shared library. When set,
+    compilation is skipped and the given library is loaded directly.
+
+``DIFF_VOXELIZE_BUILD_DIR``
+    Directory where the shared library should be built. Defaults to the module
+    directory. A ``diff_voxelize.so`` file will be created inside it if it does
+    not already exist.
+
+If neither environment variable is provided and compilation fails (for
+example because ``g++`` is missing), importing this module will raise a
+``RuntimeError`` explaining the failure.
+"""
 
 from __future__ import annotations
 
 import ctypes
 import subprocess
+import os
 from pathlib import Path
 from typing import Tuple
 
 import numpy as np
 
 ROOT = Path(__file__).resolve().parent
-LIB_PATH = ROOT / "diff_voxelize.so"
+_ENV_LIB = os.environ.get("DIFF_VOXELIZE_LIB")
+_ENV_BUILD_DIR = os.environ.get("DIFF_VOXELIZE_BUILD_DIR")
+_BUILD_DIR = Path(_ENV_BUILD_DIR) if _ENV_BUILD_DIR else ROOT
+LIB_PATH = Path(_ENV_LIB) if _ENV_LIB else _BUILD_DIR / "diff_voxelize.so"
 
 
 def _load_lib() -> ctypes.CDLL:
+    """Load the ``diff_voxelize`` shared library, compiling if necessary."""
+    if _ENV_LIB:
+        if not LIB_PATH.exists():
+            raise FileNotFoundError(
+                f"DIFF_VOXELIZE_LIB set to {LIB_PATH} but file does not exist"
+            )
+        return ctypes.CDLL(str(LIB_PATH))
+
     if not LIB_PATH.exists():
         src = ROOT / "diff_voxelize.cpp"
-        subprocess.check_call(
-            [
-                "g++",
-                "-std=c++17",
-                "-shared",
-                "-fPIC",
-                str(src),
-                "-o",
-                str(LIB_PATH),
-            ]
-        )
+        _BUILD_DIR.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.check_call(
+                [
+                    "g++",
+                    "-std=c++17",
+                    "-shared",
+                    "-fPIC",
+                    str(src),
+                    "-o",
+                    str(LIB_PATH),
+                ]
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            raise RuntimeError(
+                "Failed to compile diff_voxelize library. Ensure g++ is installed "
+                "or provide a prebuilt library via DIFF_VOXELIZE_LIB."
+            ) from exc
     return ctypes.CDLL(str(LIB_PATH))
 
 

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- allow overriding diff_voxelize build directory or library via env vars
- emit clearer error when on-the-fly g++ compilation fails
- clean up lint/type configs so tooling runs

## Testing
- `pytest`
- `mypy`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a494dae3ac832db3e3a1a6c18ee9b6