### PR TITLE
Improve LOD config error handling

### DIFF
--- a/src/world/chunk_streamer.cpp
+++ b/src/world/chunk_streamer.cpp
@@ -2,11 +2,17 @@
 #include <cmath>
 #include <thread>
 #include <chrono>
+#include <exception>
+#include <iostream>
 
 namespace voxelvk {
 
-ChunkStreamer::ChunkStreamer(const std::string& cfgPath)
+ChunkStreamer::ChunkStreamer(const std::string& cfgPath) try
     : lod_(cfgPath) {}
+catch(const std::exception& e) {
+    std::cerr << "ChunkStreamer initialization failed: " << e.what() << "\n";
+    throw;
+}
 
 ChunkStreamer::~ChunkStreamer() {
     for(auto& kv : loading_){

--- a/src/world/lod_component.cpp
+++ b/src/world/lod_component.cpp
@@ -1,6 +1,8 @@
 #include "lod_component.hpp"
 #include <fstream>
+#include <iostream>
 #include <sstream>
+#include <stdexcept>
 
 namespace voxelvk {
 
@@ -11,8 +13,9 @@ LODComponent::LODComponent(const std::string& cfgPath) {
 void LODComponent::LoadConfig(const std::string& cfgPath) {
     std::ifstream f(cfgPath);
     if(!f.is_open()) {
-        std::cerr << "Error: Could not open config file '" << cfgPath << "' in LODComponent::LoadConfig.\n";
-        return;
+        std::cerr << "Error: Could not open config file '" << cfgPath
+                  << "' in LODComponent::LoadConfig.\n";
+        throw std::runtime_error("Failed to open LOD config file");
     }
     std::string line;
     while(std::getline(f, line)){


### PR DESCRIPTION
## Summary
- include `<iostream>` and throw on LOD config file open failure
- catch and log `LODComponent` init failures in `ChunkStreamer`

## Testing
- `pytest` *(fails: IndentationError: unexpected indent)*
- `mypy` *(fails: option 'exclude' in section 'mypy' already exists)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a494e4c0f0832d8047807d01b6d161