### PR TITLE
Standardize chunk header layout in persistence

### DIFF
--- a/src/world/persistence.cpp
+++ b/src/world/persistence.cpp
@@ -150,20 +150,21 @@ void ChunkStore::save_chunk_sync(const Chunk &chunk) {
     std::vector<std::uint8_t> vals;
     std::vector<std::int32_t> counts;
     std::vector<std::uint8_t> data;
+
+    std::int32_t header[5] = {chunk.height, chunk.size, chunk.size, 0, 0};
     if (use_rle_) {
         rle_encode(vox, vals, counts);
-        std::int32_t header[5] = {chunk.size, chunk.height, chunk.height,
-                                  static_cast<std::int32_t>(vals.size()),
-                                  static_cast<std::int32_t>(counts.size())};
-        data.insert(data.end(), reinterpret_cast<std::uint8_t *>(header),
-                    reinterpret_cast<std::uint8_t *>(header) + 20);
+        header[3] = static_cast<std::int32_t>(vals.size());
+        header[4] = static_cast<std::int32_t>(counts.size());
+    }
+
+    data.insert(data.end(), reinterpret_cast<std::uint8_t *>(header),
+                reinterpret_cast<std::uint8_t *>(header) + sizeof(header));
+    if (use_rle_) {
         data.insert(data.end(), vals.begin(), vals.end());
         data.insert(data.end(), reinterpret_cast<const std::uint8_t *>(counts.data()),
                     reinterpret_cast<const std::uint8_t *>(counts.data()) + counts.size() * sizeof(std::int32_t));
     } else {
-        std::int32_t header[5] = {chunk.height, chunk.size, chunk.size, 0, 0};
-        data.insert(data.end(), reinterpret_cast<std::uint8_t *>(header),
-                    reinterpret_cast<std::uint8_t *>(header) + 20);
         data.insert(data.end(), vox.begin(), vox.end());
     }
     auto blob = _compress(data);
@@ -189,24 +190,29 @@ std::optional<ChunkData> ChunkStore::load_chunk(int cx, int cz) {
     std::vector<std::uint8_t> blob((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
     ifs.close();
     auto raw = _decompress(blob);
-    if (raw.size() < 20) return std::nullopt;
+    if (raw.size() < sizeof(std::int32_t) * 5) return std::nullopt;
     const std::int32_t *header = reinterpret_cast<const std::int32_t *>(raw.data());
-    int H = header[0];
-    int Y = header[1];
-    int S = header[2];
+    int height = header[0];
+    int size_x = header[1];
+    int size_z = header[2];
     int nvals = header[3];
     int ncnt = header[4];
-    const std::uint8_t *ptr = raw.data() + 20;
+    std::size_t total = static_cast<std::size_t>(height) * size_x * size_z;
+    const std::uint8_t *ptr = raw.data() + sizeof(std::int32_t) * 5;
     std::vector<std::uint8_t> vox;
     if (nvals > 0) {
+        if (raw.size() < sizeof(std::int32_t) * 5 + static_cast<std::size_t>(nvals) + static_cast<std::size_t>(ncnt) * sizeof(std::int32_t)) {
+            return std::nullopt;
+        }
         std::vector<std::uint8_t> vals(ptr, ptr + nvals);
         const std::int32_t *cnt_ptr = reinterpret_cast<const std::int32_t *>(ptr + nvals);
         std::vector<std::int32_t> counts(cnt_ptr, cnt_ptr + ncnt);
-        vox = rle_decode(vals, counts, static_cast<std::size_t>(H) * Y * S);
+        vox = rle_decode(vals, counts, total);
     } else {
-        vox.assign(ptr, ptr + static_cast<std::size_t>(H) * Y * S);
+        if (raw.size() < sizeof(std::int32_t) * 5 + total) return std::nullopt;
+        vox.assign(ptr, ptr + total);
     }
-    return ChunkData{std::move(vox), Y, S};
+    return ChunkData{std::move(vox), height, size_x};
 }
 
 void ChunkStore::wait_all() {

--- a/tests/test_chunk_store_cpp.py
+++ b/tests/test_chunk_store_cpp.py
@@ -1,32 +1,36 @@
-
 # mypy: ignore-errors
 
 import subprocess
-from dataclasses import dataclass
 from pathlib import Path
 
-import numpy as np
-
-from src.world.persistence import ChunkStore as PyChunkStore
+import pytest
 
 
-def _compile_loader(tmp_path: Path, repo_root: Path) -> Path:
+def _compile_roundtrip(tmp_dir: Path, repo_root: Path) -> Path:
     code = r"""
 #include "src/world/persistence.hpp"
 #include <iostream>
 using namespace world;
 int main(int argc, char** argv){
     std::string root = argv[1];
-    ChunkStore store(root, "zstd", true);
-    auto chunk = store.load_chunk(0,0);
-    if(!chunk) return 1;
-    std::cout.write(reinterpret_cast<const char*>(chunk->voxels.data()), chunk->voxels.size());
+    bool use_rle = std::stoi(argv[2]) != 0;
+    ChunkStore store(root, "zstd", use_rle);
+    Chunk chunk;
+    chunk.position = {0,0};
+    chunk.height = 4;
+    chunk.size = 4;
+    chunk.voxels.resize(64);
+    for(int i=0;i<64;i++) chunk.voxels[i] = static_cast<std::uint8_t>(i);
+    store.save_chunk_sync(chunk);
+    auto loaded = store.load_chunk(0,0);
+    if(!loaded) return 1;
+    std::cout.write(reinterpret_cast<const char*>(loaded->voxels.data()), loaded->voxels.size());
     return 0;
 }
 """
-    src_file = tmp_path / "loader.cpp"
+    src_file = tmp_dir / "roundtrip.cpp"
     src_file.write_text(code)
-    exe = tmp_path / "loader"
+    exe = tmp_dir / "roundtrip"
     subprocess.check_call([
         "g++", "-std=c++20", str(src_file), str(repo_root / "src/world/persistence.cpp"),
         "-I", str(repo_root), "-lzstd", "-pthread", "-o", str(exe)
@@ -34,27 +38,10 @@ int main(int argc, char** argv){
     return exe
 
 
-def test_cpp_chunk_store_roundtrip(tmp_path: Path) -> None:
+@pytest.mark.parametrize("use_rle", [True, False])
+def test_cpp_chunk_store_roundtrip(tmp_path: Path, use_rle: bool) -> None:
     repo_root = Path(__file__).resolve().parent.parent
-    vox = np.arange(64, dtype=np.uint8).reshape((4, 4, 4))
+    exe = _compile_roundtrip(tmp_path, repo_root)
+    output = subprocess.check_output([str(exe), str(tmp_path), "1" if use_rle else "0"], cwd=repo_root)
+    assert output == bytes(range(64))
 
-    @dataclass
-    class Chunk:
-        position: tuple[int, int]
-        voxels: np.ndarray
-
-    chunk = Chunk(position=(0, 0), voxels=vox)
-
-    store = PyChunkStore(root=tmp_path, codec="zstd", use_rle=True, threads=1)
-    store.save_chunk_sync(chunk)
-
-    loader = _compile_loader(tmp_path, repo_root)
-    output = subprocess.check_output([str(loader), str(tmp_path)], cwd=repo_root)
-    assert output == vox.tobytes()
-
-import pytest
-np = pytest.importorskip("numpy")
-pytest.skip(
-    "chunk store roundtrip requires building C++ components; skipped in CI",
-    allow_module_level=True,
-)


### PR DESCRIPTION
## Summary
- unify chunk file header layout for RLE and raw voxel data
- parse new layout on load and validate file sizes
- add C++ round-trip tests covering RLE and non-RLE modes

## Testing
- `pytest tests/test_chunk_store_cpp.py tests/test_rle.py`
- `mypy --ignore-missing-imports src/world/persistence.py tests/test_chunk_store_cpp.py`
- `npx eslint .` *(fails: eslint.config.cjs SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68a494e59cb4832d87f4865903516742