### PR TITLE
test: skip player controller tests without physics module

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,23 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: {
+        ...globals.node,
+        ...globals.es2021,
+      },
+    },
+    rules: {
+      'no-unused-vars': 'warn',
+      'semi': ['error', 'always'],
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -105,129 +26,8 @@ module.exports = [
       'shaders/**',
       'shaders_vk/**',
       'tools/**',
-      'tests/**',
       'apps/**',
-
       'scripts/**',
     ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
-    },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,15 +1,4 @@
-
-
- 
 """Axis-aligned bounding box helpers for collision tests."""
- 
-
-        main
-"""Axis-aligned bounding box helpers for collision tests."""
-
-"""Axis-aligned bounding box utilities."""
-        main
-        main
 
 from __future__ import annotations
 
@@ -21,12 +10,6 @@ from numpy.typing import NDArray
 
 @dataclass
 class AABB:
-
-    """Simple axis-aligned bounding box."""
-
- 
-    """Simple axis-aligned bounding box."""
- 
     """Simple axis-aligned bounding box.
 
     Parameters
@@ -36,8 +19,6 @@ class AABB:
     half:
         Half extents of the box along each axis.
     """
-        main
-        main
 
     center: NDArray[np.float32]
     half: NDArray[np.float32]
@@ -45,32 +26,19 @@ class AABB:
     @property
     def min(self) -> NDArray[np.float32]:
         """Minimum corner of the box."""
-
         return self.center - self.half
 
     @property
     def max(self) -> NDArray[np.float32]:
         """Maximum corner of the box."""
-
         return self.center + self.half
 
     def moved(self, delta: NDArray[np.float32]) -> "AABB":
         """Return a translated copy of this box."""
-
         return AABB(self.center + delta, self.half)
 
     def overlap_aabb(self, other: "AABB") -> bool:
-
-        """Return ``True`` if this box intersects ``other``."""
-
-
- 
-
-        """Check if this box overlaps another."""
-
-        main
-        main
-        main
+        """Return True if this box intersects ``other``."""
         return not (
             self.max[0] <= other.min[0] or self.min[0] >= other.max[0] or
             self.max[1] <= other.min[1] or self.min[1] >= other.max[1] or
@@ -79,4 +47,3 @@ class AABB:
 
 
 __all__ = ["AABB"]
-

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -1,17 +1,17 @@
 import pytest
 import numpy as np
 
-try:  # The player controller module is currently broken; skip tests if import fails.
-    from src.physics.player_controller_capsule import (
-        PlayerControllerCapsule,
-        SPRINT_SPEED_MULTIPLIER,
-        get_horizontal_speed,
+try:  # skip tests if native module is unavailable or broken
+    physics = pytest.importorskip(
+        "src.physics.player_controller_capsule",
+        reason="player_controller_capsule module unavailable",
     )
-except Exception:  # pragma: no cover - skip if module cannot be imported
-    pytest.skip(
-        "player_controller_capsule module unavailable",
-        allow_module_level=True,
-    )
+except Exception:  # pragma: no cover
+    pytest.skip("player_controller_capsule module unavailable", allow_module_level=True)
+
+PlayerControllerCapsule = physics.PlayerControllerCapsule
+SPRINT_SPEED_MULTIPLIER = physics.SPRINT_SPEED_MULTIPLIER
+get_horizontal_speed = physics.get_horizontal_speed
 
 
 class FlatWorld:
@@ -86,39 +86,3 @@ def test_sprint_speed_limit():
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- conditionally import player controller capsule tests using `pytest.importorskip`
- remove unconditional module-level skip so tests run when physics module is present

## Testing
- `pytest`
- `npx eslint .` *(fails: SyntaxError in `eslint.config.cjs`)*
- `mypy .` *(fails: duplicate option in config and unexpected indent in `src/physics/aabb.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68a494f92d70832da254fa4e64864bfe