### PR TITLE
Simplify mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
 explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+exclude = ^src/physics/|tests/

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -96,29 +96,3 @@ pytest.skip(
 )
 
 
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- condense mypy.ini to a single section with explicit_package_bases
- trim stray lines from player controller test module

## Testing
- `pytest` (skipped)
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a4d253a714832da13b576e4916b447