### PR TITLE
Handle optional compression imports for mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,12 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
 
+[mypy-zstandard]
+ignore_missing_imports = True
 
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
+[mypy-lz4.*]
+ignore_missing_imports = True
 
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -3,9 +3,13 @@ import json
 import logging
 import numpy as np
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 from concurrent.futures import Future, ThreadPoolExecutor
 from .rle import rle_encode, rle_decode
+
+if TYPE_CHECKING:
+    import zstandard as zstd
+    import lz4.frame as lz4f
 
 try:
     import zstandard as zstd


### PR DESCRIPTION
## Summary
- add TYPE_CHECKING block for optional compression libraries
- simplify mypy configuration and ignore missing imports for zstandard and lz4

## Testing
- `npx eslint .` *(fails: Unexpected token '.' in eslint.config.cjs)*
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py:114)*
- `mypy --config-file mypy.ini src/world/persistence.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4c9515910832da753d379ae1a07c8