### PR TITLE
Clean up player controller capsule test

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,21 +1,10 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
 module.exports = [
   js.configs.recommended,
   {
     ignores: [
-
-
-
-
       'build/**',
       'node_modules/',
       'build_ci_sanity/',
@@ -30,204 +19,14 @@ module.exports = [
       'apps/',
       'scripts/'
     ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
       globals: { ...globals.node, ...globals.es2021 }
     },
-    ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-
-      'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
     rules: {
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
   }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
-files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -86,39 +86,3 @@ def test_sprint_speed_limit():
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- remove obsolete skip block and stray lines in player controller capsule tests
- restore ESLint and mypy configs so linting and type checks run

## Testing
- `pytest`
- `npx eslint .`
- `mypy src`


------
https://chatgpt.com/codex/tasks/task_e_68a4d25519ec832d87268467fbadb5f8