### PR TITLE
refactor: clean eslint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,52 +1,6 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
@@ -56,47 +10,7 @@ module.exports = [
       globals: { ...globals.node, ...globals.es2021 }
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -107,127 +21,11 @@ module.exports = [
       'tools/**',
       'tests/**',
       'apps/**',
-
-      'scripts/**',
-    ],
-
-
       'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
       'semi': ['error', 'always']
     }
   }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,37 +88,7 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- replace corrupted ESLint config with single module.exports
- prune mypy config duplicates
- tidy player controller tests for clean run

## Testing
- `npx eslint .`
- `mypy`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5a813dc832d882f8eff00e31907