### PR TITLE
Document mypy exclusions for tests and physics

### DIFF
--- a/docs/MYPY_EXCLUSIONS.md
+++ b/docs/MYPY_EXCLUSIONS.md
@@ -1,0 +1,10 @@
+# Mypy Exclusions
+
+The project's `mypy.ini` excludes certain paths from type checking using the pattern
+`exclude = ^(src/physics/|tests/)`.
+
+- `src/physics/` – physics routines not yet typed.
+- `tests/` – all test modules, including `tests/test_capsule_ground.py`.
+
+These directories are skipped during type checking to keep the build fast while these areas
+are still under development.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,233 +1,32 @@
-const js = require('@eslint/js');
-const globals = require('globals');
-
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
+const js = require("@eslint/js");
+const globals = require("globals");
 
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-
-      'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
+      sourceType: "script",
       globals: { ...globals.node, ...globals.es2021 },
     },
+    ignores: [
+      "build/**",
+      "node_modules/**",
+      "build_ci_sanity/**",
+      "cmake/**",
+      "docs/**",
+      "assets/**",
+      "shaders/**",
+      "shaders_vk/**",
+      "tools/**",
+      "tests/**",
+      "src/**",
+      "apps/**",
+      "scripts/**",
+    ],
     rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
+      "no-unused-vars": "warn",
+      semi: ["error", "always"],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -94,31 +94,3 @@ pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- streamline `mypy.ini` to exclude physics module and tests directory
- document MyPy exclusions including coverage of `tests/test_capsule_ground.py`

## Testing
- `npx prettier docs/MYPY_EXCLUSIONS.md --write`
- `pytest -q` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy --config-file mypy.ini`

------
https://chatgpt.com/codex/tasks/task_e_68a4d5f8379c832d8460eb1b33844424