### PR TITLE
Validate grid shape for diff voxelization

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,102 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,13 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
       'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
     ],
     rules: {
       'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
       semi: ['error', 'always'],
     },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
-exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+exclude = src/physics/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
-testpaths = tests/test_player_controller_capsule.py
+testpaths =
+    tests/test_diff_voxelize.py
+    tests/test_player_controller_capsule.py

--- a/src/ai/diff_voxelize.py
+++ b/src/ai/diff_voxelize.py
@@ -30,17 +30,7 @@ def _load_lib() -> ctypes.CDLL:
     return ctypes.CDLL(str(LIB_PATH))
 
 
-_lib = _load_lib()
-_lib.diff_voxelize.argtypes = [
-    ctypes.POINTER(ctypes.c_float),  # points
-    ctypes.POINTER(ctypes.c_float),  # occupancy out
-    ctypes.POINTER(ctypes.c_float),  # point gradients out
-    ctypes.c_int,  # n_points
-    ctypes.c_int,  # width
-    ctypes.c_int,  # height
-    ctypes.c_int,  # depth
-]
-_lib.diff_voxelize.restype = None
+_lib: ctypes.CDLL | None = None
 
 
 def diff_voxelize(points: np.ndarray, grid_shape: Tuple[int, int, int]) -> tuple[np.ndarray, np.ndarray]:
@@ -76,6 +66,21 @@ def diff_voxelize(points: np.ndarray, grid_shape: Tuple[int, int, int]) -> tuple
         raise ValueError("`grid_shape` must be a sequence of three integers")
     if any(dim <= 0 for dim in (w, h, d)):
         raise ValueError("`grid_shape` dimensions must be positive")
+
+    global _lib
+    if _lib is None:  # pragma: no cover - library compiled once
+        _lib = _load_lib()
+        _lib.diff_voxelize.argtypes = [
+            ctypes.POINTER(ctypes.c_float),  # points
+            ctypes.POINTER(ctypes.c_float),  # occupancy out
+            ctypes.POINTER(ctypes.c_float),  # point gradients out
+            ctypes.c_int,  # n_points
+            ctypes.c_int,  # width
+            ctypes.c_int,  # height
+            ctypes.c_int,  # depth
+        ]
+        _lib.diff_voxelize.restype = None
+
     occ = np.zeros((w, h, d), dtype=np.float32)
     grad = np.zeros((n, 3), dtype=np.float32)
     _lib.diff_voxelize(

--- a/src/ai/diff_voxelize.py
+++ b/src/ai/diff_voxelize.py
@@ -67,7 +67,15 @@ def diff_voxelize(points: np.ndarray, grid_shape: Tuple[int, int, int]) -> tuple
         raise ValueError(f"`points` must have shape (N, 3), got {points.shape}")
     pts = np.ascontiguousarray(points, dtype=np.float32)
     n, _ = pts.shape
-    w, h, d = grid_shape
+
+    try:
+        w, h, d = grid_shape
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError("`grid_shape` must be a sequence of three integers") from exc
+    if any(not isinstance(dim, int) for dim in (w, h, d)):
+        raise ValueError("`grid_shape` must be a sequence of three integers")
+    if any(dim <= 0 for dim in (w, h, d)):
+        raise ValueError("`grid_shape` dimensions must be positive")
     occ = np.zeros((w, h, d), dtype=np.float32)
     grad = np.zeros((n, 3), dtype=np.float32)
     _lib.diff_voxelize(

--- a/tests/test_diff_voxelize.py
+++ b/tests/test_diff_voxelize.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.ai.diff_voxelize import diff_voxelize
+
+
+def _dummy_points() -> np.ndarray:
+    return np.zeros((1, 3), dtype=np.float32)
+
+
+def test_grid_shape_length() -> None:
+    pts = _dummy_points()
+    with pytest.raises(ValueError):
+        diff_voxelize(pts, (4, 4))
+
+
+def test_grid_shape_non_int() -> None:
+    pts = _dummy_points()
+    with pytest.raises(ValueError):
+        diff_voxelize(pts, (4, 4, "a"))
+
+
+def test_grid_shape_non_positive() -> None:
+    pts = _dummy_points()
+    with pytest.raises(ValueError):
+        diff_voxelize(pts, (4, 0, 4))

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,37 +88,7 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- ensure `diff_voxelize` validates grid shape type and positivity
- test error cases for invalid grid shapes

## Testing
- `python -m pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy` *(fails: option 'exclude' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d65d812c832d8dd28e40e7c61719