### PR TITLE
docs: clarify optional ai binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ This repo contains:
 - GitHub Actions CI (Linux & Windows) that installs Vulkan SDK, builds, tests, and publishes artifacts
 See [Quickstart guide](docs/QUICKSTART.md) for setup and usage.
 
+## Prebuilt binaries
+
+Certain features under `src/ai/` require platform-specific binaries. These
+artifacts are **not** checked into the repository. If you need them, download
+the appropriate package for your operating system from the project's
+[releases page](https://github.com/<owner>/<repo>/releases) or build them
+yourself following the Quickstart guide. Place the resulting files in
+`src/ai/` to enable the optional functionality.
+
 ## Local build
 ```bash
 cmake -S . -B build -G Ninja -DENABLE_IMGUI_OVERLAY=ON -DVOXELVK_ENABLE_CUDA=OFF -DVOXELVK_ENABLE_TENSORRT=OFF


### PR DESCRIPTION
## Summary
- note that AI binaries are optional and not stored in git
- link to releases page with instructions to download or build them

## Testing
- ⚠️ `pytest` (skipped: docs-only change)
- ⚠️ `npx eslint .` (skipped: docs-only change)
- ⚠️ `mypy` (skipped: docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68a4d6641d08832d8d0222062dc2f1f2