### PR TITLE
Normalize codec flag assignments

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,52 +1,6 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-
-
-      'build/**',
-      'node_modules/',
-      'build_ci_sanity/',
-      'cmake/',
-      'docs/',
-      'assets/',
-      'shaders/',
-      'shaders_vk/',
-      'tools/',
-      'tests/',
-      'src/',
-      'apps/',
-      'scripts/'
-    ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
 module.exports = [
   js.configs.recommended,
   {
@@ -56,47 +10,7 @@ module.exports = [
       globals: { ...globals.node, ...globals.es2021 }
     },
     ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
+      'build/**',
       'node_modules/**',
       'build_ci_sanity/**',
       'cmake/**',
@@ -106,128 +20,9 @@ module.exports = [
       'shaders_vk/**',
       'tools/**',
       'tests/**',
+      'src/**',
       'apps/**',
-
-      'scripts/**',
-    ],
-
-
       'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
     ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
   }
 ];
-
-
-
-      semi: ['error', 'always'],
-    },
-  },
-];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -1,4 +1,3 @@
-
 import json
 import logging
 import numpy as np
@@ -9,37 +8,53 @@ from .rle import rle_encode, rle_decode
 
 try:
     import zstandard as zstd
-    has_zstd=True
+
+    has_zstd = True
 except Exception:
-    has_zstd=False
+    has_zstd = False
 try:
     import lz4.frame as lz4f
-    has_lz4=True
+
+    has_lz4 = True
 except Exception:
-    has_lz4=False
+    has_lz4 = False
+
 
 class ChunkStore:
     def __init__(self, root="world_save", codec="zstd", use_rle=True, threads=4):
-        self.root = Path(root); self.root.mkdir(parents=True, exist_ok=True)
-        self.codec = codec; self.use_rle = use_rle
-        self.pool = ThreadPoolExecutor(max_workers=max(1,threads))
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.codec = codec
+        self.use_rle = use_rle
+        self.pool = ThreadPoolExecutor(max_workers=max(1, threads))
         self.futures: Dict[str, Future] = {}
 
     def _region_dir(self, cx, cz):
-        d = self.root / f"r.{cx//32}.{cz//32}"; d.mkdir(exist_ok=True); return d
-    def chunk_path(self, cx, cz): return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
+        d = self.root / f"r.{cx//32}.{cz//32}"
+        d.mkdir(exist_ok=True)
+        return d
+
+    def chunk_path(self, cx, cz):
+        return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
 
     def _compress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
-            c = zstd.ZstdCompressor(level=10); return c.compress(b)
-        if self.codec=="lz4" and has_lz4:
-            return lz4f.compress(b, compression_level=9, block_size=lz4f.BLOCKSIZE_MAX1MB, content_checksum=True)
+        if self.codec == "zstd" and has_zstd:
+            c = zstd.ZstdCompressor(level=10)
+            return c.compress(b)
+        if self.codec == "lz4" and has_lz4:
+            return lz4f.compress(
+                b,
+                compression_level=9,
+                block_size=lz4f.BLOCKSIZE_MAX1MB,
+                content_checksum=True,
+            )
         return b
 
     def _decompress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
-            d = zstd.ZstdDecompressor(); return d.decompress(b)
-        if self.codec=="lz4" and has_lz4:
+        if self.codec == "zstd" and has_zstd:
+            d = zstd.ZstdDecompressor()
+            return d.decompress(b)
+        if self.codec == "lz4" and has_lz4:
             return lz4f.decompress(b)
         return b
 
@@ -49,11 +64,16 @@ class ChunkStore:
             vox = chunk.voxels.astype(np.uint8)
             if self.use_rle:
                 vals, counts, shape = rle_encode(vox)
-                header = np.array([shape[0], shape[1], shape[2], vals.size, counts.size], dtype=np.int32).tobytes()
+                header = np.array(
+                    [shape[0], shape[1], shape[2], vals.size, counts.size],
+                    dtype=np.int32,
+                ).tobytes()
                 payload = vals.tobytes() + counts.tobytes()
                 data = header + payload
             else:
-                header = np.array([vox.shape[0], vox.shape[1], vox.shape[2], 0, 0], dtype=np.int32).tobytes()
+                header = np.array(
+                    [vox.shape[0], vox.shape[1], vox.shape[2], 0, 0], dtype=np.int32
+                ).tobytes()
                 data = header + vox.tobytes()
             blob = self._compress(data)
             self.chunk_path(cx, cz).write_bytes(blob)
@@ -81,18 +101,19 @@ class ChunkStore:
 
     def load_chunk(self, cx, cz) -> Optional[Dict]:
         p = self.chunk_path(cx, cz)
-        if not p.exists(): return None
+        if not p.exists():
+            return None
         blob = p.read_bytes()
         raw = self._decompress(blob)
         header = np.frombuffer(raw[:20], dtype=np.int32)
         H, Y, S, nvals, ncnt = header.tolist()
         rest = raw[20:]
-        if nvals>0:
+        if nvals > 0:
             vals = np.frombuffer(rest[:nvals], dtype=np.uint8)
-            counts = np.frombuffer(rest[nvals:nvals+4*ncnt], dtype=np.int32)
-            vox = rle_decode(vals, counts, (H,Y,S))
+            counts = np.frombuffer(rest[nvals : nvals + 4 * ncnt], dtype=np.int32)
+            vox = rle_decode(vals, counts, (H, Y, S))
         else:
-            vox = np.frombuffer(rest, dtype=np.uint8).reshape((H,Y,S))
+            vox = np.frombuffer(rest, dtype=np.uint8).reshape((H, Y, S))
         return {"voxels": vox, "height": int(Y), "size": int(S)}
 
     def wait_all(self):

--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -88,37 +88,7 @@ def test_sprint_speed_limit():
     assert sprint_speed > speed
 
 
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- use PEP 8 spacing for `has_zstd`/`has_lz4` flags in `persistence.py`
- trim stray lines in `tests/test_player_controller_capsule.py`
- clean up `mypy.ini` and `eslint.config.cjs`

## Testing
- `python -m black src/world/persistence.py`
- `python -m black tests/test_player_controller_capsule.py`
- `pytest`
- `mypy`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4da5c5640832da2c27b07486327a2