### PR TITLE
Clean up player controller capsule tests

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -87,38 +87,7 @@ def test_sprint_speed_limit():
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
 
-
-
-
 pytest.skip(
     "player controller capsule tests require native physics module; skipped in CI",
     allow_module_level=True,
 )
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- remove stray text after module-level skip in player controller capsule tests

## Testing
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.' in eslint.config.cjs)*
- `mypy --config-file=/dev/null tests/test_player_controller_capsule.py`
- `pytest`
- `pytest tests/test_player_controller_capsule.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4da5cce5c832db119f302ba5463b4