### PR TITLE
chore: clean up player controller capsule tests

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -86,39 +86,3 @@ def test_sprint_speed_limit():
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- remove redundant skip block from player controller capsule tests
- drop stray `main` placeholders and end file cleanly

## Testing
- `pytest`
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: option 'exclude' in section 'mypy' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a4daa62768832dbc0df64ed6b04e9a