### PR TITLE
Remove stray main line from capsule properties test

### DIFF
--- a/tests/test_capsule_properties.py
+++ b/tests/test_capsule_properties.py
@@ -13,7 +13,6 @@ try:  # Skip tests if the capsule module is unavailable or invalid.
     from src.physics.capsule import Capsule
 except (ImportError, ModuleNotFoundError):  # pragma: no cover - skip if module import fails
     pytest.skip("capsule module unavailable", allow_module_level=True)
-        main
 
 def test_seg_properties():
     cap = Capsule(


### PR DESCRIPTION
## Summary
- remove stray `main` line from `test_capsule_properties`

## Testing
- `pytest tests/test_capsule_properties.py`
- `npx eslint tests/test_capsule_properties.py` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy tests/test_capsule_properties.py` *(fails: option 'exclude' already exists; syntax error in src/physics/capsule.py)*
- `mypy --config-file=/dev/null --follow-imports=skip --ignore-missing-imports --disable-error-code=syntax tests/test_capsule_properties.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4dacfec8c832d8b14eab5a944588d