### PR TITLE
Refactor player controller test import

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -1,17 +1,15 @@
 import pytest
 import numpy as np
 
-try:  # The player controller module is currently broken; skip tests if import fails.
-    from src.physics.player_controller_capsule import (
-        PlayerControllerCapsule,
-        SPRINT_SPEED_MULTIPLIER,
-        get_horizontal_speed,
-    )
-except Exception:  # pragma: no cover - skip if module cannot be imported
-    pytest.skip(
-        "player_controller_capsule module unavailable",
-        allow_module_level=True,
-    )
+player_controller = pytest.importorskip(
+    "src.physics.player_controller_capsule",
+    reason="player_controller_capsule module unavailable",
+)
+from player_controller import (
+    PlayerControllerCapsule,
+    SPRINT_SPEED_MULTIPLIER,
+    get_horizontal_speed,
+)
 
 
 class FlatWorld:
@@ -86,39 +84,3 @@ def test_sprint_speed_limit():
     sprint_speed = get_horizontal_speed(player)
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
-
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- streamline player_controller_capsule tests to use pytest.importorskip for missing module

## Testing
- `pytest -q` (skipped tests when module missing)
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.')*
- `mypy` *(fails: option 'exclude' in section 'mypy' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db2ccd90832d8ce7a467525c1244