### PR TITLE
Remove redundant skip from player controller tests

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -87,38 +87,3 @@ def test_sprint_speed_limit():
     assert sprint_speed <= player.max_speed * SPRINT_SPEED_MULTIPLIER + 1e-3
     assert sprint_speed > speed
 
-
-
-
-pytest.skip(
-    "player controller capsule tests require native physics module; skipped in CI",
-    allow_module_level=True,
-)
-
-
-
-
-
-
-
-
-
-
-
-
- 
-
-
-
-
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- remove extra pytest.skip block from player controller capsule tests
- delete stray "main" lines left at file end

## Testing
- `python -m py_compile tests/test_player_controller_capsule.py`
- `pytest`
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.' in eslint.config.cjs)*
- `mypy` *(fails: option 'exclude' already exists)*


------
https://chatgpt.com/codex/tasks/task_e_68a4db55c3d0832dab42f1db082b2873