### PR TITLE
Clean up capsule properties test and configs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,22 +1,16 @@
 const js = require('@eslint/js');
 const globals = require('globals');
 
-
-
-
-
-
-        main
-
 module.exports = [
   js.configs.recommended,
   {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'script',
+      globals: { ...globals.node, ...globals.es2021 },
+    },
     ignores: [
-
-
-
-
-      'build/**',
+      '**/build/**',
       'node_modules/',
       'build_ci_sanity/',
       'cmake/',
@@ -28,206 +22,7 @@ module.exports = [
       'tests/',
       'src/',
       'apps/',
-      'scripts/'
+      'scripts/',
     ],
-
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-        main
-      '**/build/**',
-
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
-    },
-    ignores: [
-
-
-
-        main
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-
-    ignores: [
-
-    ignores: [
-        main
-        main
-      '**/build/**',
-
-
-const globals = require('globals');
-
-module.exports = [
-  js.configs.recommended,
-  {
-    ignores: [
-
-
-const globals = require('globals');
-
-        main
-
-module.exports = [
-  js.configs.recommended,
-  
-  {   ignores: [
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'apps/**',
-
-      'scripts/**',
-    ],
-
-
-      'scripts/**'
-    ],
-
-
-      'scripts/**',
-
-      '**/build/**'
-    ]
-
-      '**/build/**'
-    ]
-
-
-      'scripts/**',
-      '**/build/**'
-    ]
- 
-
-      'scripts/**',
-      'build/**'
-    ],
-    rules: {
-      'no-unused-vars': 'warn',
-      'semi': ['error', 'always']
-    }
-  }
-
-
-      'scripts/**'
-    ],
-
-      'scripts/**',
-
-      '**/build/**',
-    ],
-        main
-        main
-        main
-        main
-        main
-  },
-  {
-
-      '**/build/**'
-    ],
-        main
-        main
-        main
-    languageOptions: {
-      ecmaVersion: 2021,
-      sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 },
-    },
-    rules: {
-      'no-unused-vars': 'warn',
-
-      semi: ['error', 'always']
-    }
-  }
-];
-
-
-
-      semi: ['error', 'always'],
-    },
   },
 ];
-
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-];
-
-
-      semi: ['error', 'always'],
-    },
-  },
-
-
-      'semi': ['error', 'always']
-    }
-  }
-
-
-];
-
-
-      semi: ['error', 'always']
-    }
-  }
-
-
-      semi: ['error', 'always'],
-
-    },
-  },
-
-    }
-  }
-
-    ignores: ['node_modules/**', '**/build/**'],
-  },
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-];
-
-        main
-        main
-        main
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-
 explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main

--- a/tests/test_capsule_properties.py
+++ b/tests/test_capsule_properties.py
@@ -6,14 +6,12 @@ pytest.skip(
     allow_module_level=True,
 )
 
-from src.physics.capsule import Capsule
-
 np = pytest.importorskip("numpy")
 try:  # Skip tests if the capsule module is unavailable or invalid.
     from src.physics.capsule import Capsule
 except (ImportError, ModuleNotFoundError):  # pragma: no cover - skip if module import fails
     pytest.skip("capsule module unavailable", allow_module_level=True)
-        main
+
 
 def test_seg_properties():
     cap = Capsule(


### PR DESCRIPTION
## Summary
- remove stray text and duplicate Capsule import from capsule property tests
- simplify eslint and mypy configs to eliminate stray text

## Testing
- `python -m py_compile tests/test_capsule_properties.py`
- `npx eslint .`
- `mypy .`
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db56d23c832d9c0767d6db46eb35