### PR TITLE
chore: simplify mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,42 +1,4 @@
 [mypy]
 ignore_missing_imports = True
-
-explicit_package_bases = True
-
-
-
 files = src
-
-
 exclude = ^(src/physics/|tests/)
-
-
-exclude = ^(src/physics/|tests/)
-explicit_package_bases = True
-
-explicit_package_bases = True
-
-
-exclude = ^(src/physics/|tests/)
-
-exclude = ^src/physics/
-
-
-exclude = (?x)
-    ^src/physics/
-    |tests/test_capsule_ground.py
-
-
-# Skip type checking for physics module and tests
-        main
-exclude = ^(src/physics/|tests/)
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main
-        main


### PR DESCRIPTION
## Summary
- clean up mypy.ini to use a single section with ignore_missing_imports, files, and exclude

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_68a4db9a3f80832d94f2556014e00f22