### PR TITLE
Ensure diff_voxelize reloads cleanly

### DIFF
--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,5 +1,27 @@
 """AI helpers and differentiable voxelization bindings."""
 
-from .diff_voxelize import diff_voxelize
+from __future__ import annotations
+
+import importlib
+import sys
+from types import ModuleType
+
+
+def _load() -> ModuleType:
+    """Import ``diff_voxelize`` with a clean cache.
+
+    Any existing ``diff_voxelize`` modules are removed from ``sys.modules``
+    before importing to ensure a fresh copy is loaded. ``importlib.reload``
+    is used explicitly for clarity.
+    """
+
+    for name in ("src.ai.diff_voxelize", "ai.diff_voxelize"):
+        sys.modules.pop(name, None)
+    module = importlib.import_module("src.ai.diff_voxelize")
+    return importlib.reload(module)
+
+
+diff_voxelize = _load().diff_voxelize
 
 __all__ = ["diff_voxelize"]
+


### PR DESCRIPTION
## Summary
- ensure diff_voxelize is imported after purging cached modules and explicitly reloaded

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError: Unexpected token '.')*
- `mypy` *(fails: option 'exclude' in section 'mypy' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a4db98d574832d81f7472038b36bc0