### PR TITLE
chore: ignore AI binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ node_modules/
 **/__pycache__/
         main
 tests/physics_cpp.so
+
+# Ignore AI binaries
+src/ai/*
+!src/ai/README.md


### PR DESCRIPTION
## Summary
- ignore `src/ai` directory to keep generated binaries out of version control

## Testing
- `pytest` *(fails: IndentationError in tests/test_player_controller_capsule.py)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy .` *(fails: configuration error and unexpected indent in src/physics/aabb.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dba7a6e0832da214ed679c36dba0