### PR TITLE
Copy AABB half extents on move

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,18 +1,13 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
       'build/**',
@@ -27,8 +22,8 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-    ]
-  }
+      'scripts/**',
+    ],
+  },
 ];
-        main
+

--- a/src/physics/aabb.py
+++ b/src/physics/aabb.py
@@ -1,15 +1,4 @@
-
-
- 
-"""Axis-aligned bounding box helpers for collision tests."""
- 
-
-        main
-"""Axis-aligned bounding box helpers for collision tests."""
-
 """Axis-aligned bounding box utilities."""
-        main
-        main
 
 from __future__ import annotations
 
@@ -21,12 +10,6 @@ from numpy.typing import NDArray
 
 @dataclass
 class AABB:
-
-    """Simple axis-aligned bounding box."""
-
- 
-    """Simple axis-aligned bounding box."""
- 
     """Simple axis-aligned bounding box.
 
     Parameters
@@ -36,8 +19,6 @@ class AABB:
     half:
         Half extents of the box along each axis.
     """
-        main
-        main
 
     center: NDArray[np.float32]
     half: NDArray[np.float32]
@@ -57,20 +38,12 @@ class AABB:
     def moved(self, delta: NDArray[np.float32]) -> "AABB":
         """Return a translated copy of this box."""
 
-        return AABB(self.center + delta, self.half)
+        delta = delta.astype(self.center.dtype, copy=False)
+        return AABB(self.center + delta, self.half.copy())
 
     def overlap_aabb(self, other: "AABB") -> bool:
-
         """Return ``True`` if this box intersects ``other``."""
 
-
- 
-
-        """Check if this box overlaps another."""
-
-        main
-        main
-        main
         return not (
             self.max[0] <= other.min[0] or self.min[0] >= other.max[0] or
             self.max[1] <= other.min[1] or self.min[1] >= other.max[1] or

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,6 +1,9 @@
 from src.renderer.material_manager import MaterialManager
 
 
+MATERIAL_COMPONENTS_COUNT = 5
+
+
 def test_material_manager_loads_and_ids_unique():
     mgr = MaterialManager()
     grass = mgr.get_material_id("GRASS")


### PR DESCRIPTION
## Summary
- ensure AABB.moved copies half extents and preserves dtype
- define MATERIAL_COMPONENTS_COUNT constant for material manager test
- replace malformed ESLint configuration for lint runs

## Testing
- `mypy src/physics/aabb.py`
- `pytest -q`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4ed20d860832db67bb4efecb52249