### PR TITLE
chore: clean up mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-files = src
-exclude = ^src/physics/
-
-
 explicit_package_bases = True
 files = src
-exclude = (tests/|src/physics/)
-        main
+exclude = ^(src/physics/|tests/)
+


### PR DESCRIPTION
## Summary
- consolidate mypy configuration and fix stray text

## Testing
- `npx eslint .` *(fails: Unexpected token ':' in eslint.config.cjs)*
- `pytest`
- `mypy tests/test_capsule_properties.py` *(fails: can't read file 'tests/test_capsule_properties.py')*
- `mypy tests/test_material_manager.py` *(fails: Argument 2 to "Material" has incompatible type)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed4588e0832d9feaa5a3b6cce9a3