### PR TITLE
Fix corrupted ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,34 +1,18 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
-      'build/**',
-      'node_modules/**',
-      'build_ci_sanity/**',
-      'cmake/**',
-      'docs/**',
-      'assets/**',
-      'shaders/**',
-      'shaders_vk/**',
-      'tools/**',
-      'tests/**',
-      'src/**',
-      'apps/**',
-      'scripts/**'
-    ]
-  }
+      'build/**', 'node_modules/**', 'build_ci_sanity/**', 'cmake/**',
+      'docs/**', 'assets/**', 'shaders/**', 'shaders_vk/**', 'tools/**',
+      'tests/**', 'src/**', 'apps/**', 'scripts/**'
+    ],
+  },
 ];
-        main


### PR DESCRIPTION
## Summary
- replace broken eslint.config.cjs with a minimal working configuration

## Testing
- `pytest` *(fails: NameError: MATERIAL_COMPONENTS_COUNT is not defined)*
- `npx eslint tests/test_capsule_properties.py` *(fails: No files matching the pattern "tests/test_capsule_properties.py" were found)*
- `npx eslint tests/test_material_manager.py`
- `mypy` *(fails: option 'files' in section 'mypy' already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed46d80c832d8e7362c59cf9c225