### PR TITLE
test: make capsule test skip gracefully

### DIFF
--- a/tests/test_capsule_properties.py
+++ b/tests/test_capsule_properties.py
@@ -1,0 +1,16 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+
+try:
+    from src.physics.capsule import Capsule
+except Exception as exc:  # module may be missing or invalid
+    pytest.skip(f"src.physics.capsule is unavailable: {exc}", allow_module_level=True)
+
+
+def test_capsule_properties() -> None:
+    center = np.array([0.0, 0.0, 0.0], dtype=np.float32)
+    cap = Capsule(center, 1.0, 0.5)
+    assert np.allclose(cap.center, center)
+    assert cap.half_height == pytest.approx(1.0)
+    assert cap.radius == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add capsule property test that gracefully skips when physics module is unavailable

## Testing
- `pytest tests/test_capsule_properties.py -q`
- `pytest tests -q` *(fails: NameError: name 'MATERIAL_COMPONENTS_COUNT' is not defined)*
- `npx eslint .` *(fails: SyntaxError: Unexpected token ':' in eslint.config.cjs)*
- `mypy` *(fails: mypy.ini: option 'files' already exists; Missing target module, package, files, or command)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ed4801b8832d8722823510cbbe75