### PR TITLE
Ignore AI build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ node_modules/
 **/__pycache__/
         main
 tests/physics_cpp.so
+
+# Ignore AI binaries
+src/ai/*
+!src/ai/README.md


### PR DESCRIPTION
## Summary
- ignore src/ai build outputs while preserving README

## Testing
- `pytest` *(fails: NameError: MATERIAL_COMPONENTS_COUNT is not defined)*
- `npx eslint .` *(fails: eslint.config.cjs SyntaxError: Unexpected token ':')*
- `mypy --config-file mypy.ini` *(fails: option 'files' in section 'mypy' already exists; Missing target module)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edaad26c832d8613edaa26a63ca8