### PR TITLE
Simplify mypy config and tidy renderer utilities

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,14 +1,9 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
@@ -31,4 +26,4 @@ module.exports = [
     ]
   }
 ];
-        main
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,4 @@
 [mypy]
 ignore_missing_imports = True
 files = src
-exclude = ^src/physics/
-
-
-explicit_package_bases = True
-files = src
 exclude = (tests/|src/physics/)
-        main

--- a/src/renderer/ibl.py
+++ b/src/renderer/ibl.py
@@ -1,4 +1,3 @@
-
 """Image based lighting helpers."""
 
 from .material_manager import MaterialManager
@@ -6,16 +5,16 @@ from .material_manager import MaterialManager
 _manager = MaterialManager()
 
 
-def build_brdf_lut(material_name: str, *args, **kwargs):
-    """Build a BRDF lookup texture for the given material."""
-
-
-
-
-def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs):
+def build_brdf_lut(
+    material_name: str,
+    manager: MaterialManager = _manager,
+    *args,
+    **kwargs,
+) -> None:
     """Build a BRDF lookup texture for the given material."""
 
     material_id = manager.get_material_id(material_name)
     raise NotImplementedError(
         f"Implement using your rendering backend (material id {material_id})."
     )
+

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
+
+
+MATERIAL_COMPONENTS_COUNT = 5
 
 
 @dataclass
@@ -33,7 +36,10 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            albedo = cast(
+                Tuple[float, float, float],
+                tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0])),
+            )
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,4 +1,7 @@
-from src.renderer.material_manager import MaterialManager
+from src.renderer.material_manager import (
+    MATERIAL_COMPONENTS_COUNT,
+    MaterialManager,
+)
 
 
 def test_material_manager_loads_and_ids_unique():


### PR DESCRIPTION
## Summary
- consolidate mypy configuration and remove duplicate options
- expose `MATERIAL_COMPONENTS_COUNT` and clean up renderer helpers
- restore ESLint config for basic linting

## Testing
- `npx eslint .`
- `pytest`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a4edc3bb1c832db05f66e1163f10b4