### PR TITLE
Expand pytest discovery to full test suite

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,14 +1,9 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
@@ -31,4 +26,3 @@ module.exports = [
     ]
   }
 ];
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-files = src
-exclude = ^src/physics/
-
-
 explicit_package_bases = True
 files = src
 exclude = (tests/|src/physics/)
-        main

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = tests/test_material_manager.py
+testpaths = tests

--- a/src/renderer/ibl.py
+++ b/src/renderer/ibl.py
@@ -6,13 +6,12 @@ from .material_manager import MaterialManager
 _manager = MaterialManager()
 
 
-def build_brdf_lut(material_name: str, *args, **kwargs):
-    """Build a BRDF lookup texture for the given material."""
-
-
-
-
-def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs):
+def build_brdf_lut(
+    material_name: str,
+    manager: MaterialManager = _manager,
+    *args,
+    **kwargs,
+):
     """Build a BRDF lookup texture for the given material."""
 
     material_id = manager.get_material_id(material_name)

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
+
+
+MATERIAL_COMPONENTS_COUNT = 5
 
 
 @dataclass
@@ -33,7 +36,8 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            albedo_vals = [float(x) for x in props.get("albedo", [1.0, 1.0, 1.0])][:3]
+            albedo = cast(Tuple[float, float, float], tuple(albedo_vals))
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)
@@ -43,7 +47,6 @@ class MaterialManager:
     def get_material_id(self, name: str) -> int:
         """Return the numeric ID for a material name."""
 
-        return self._materials_by_name[name].id
         if name not in self._materials_by_name:
             raise ValueError(f"Material {name} not found")
         return self._materials_by_name[name].id

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,4 +1,7 @@
-from src.renderer.material_manager import MaterialManager
+from src.renderer.material_manager import (
+    MATERIAL_COMPONENTS_COUNT,
+    MaterialManager,
+)
 
 
 def test_material_manager_loads_and_ids_unique():


### PR DESCRIPTION
## Summary
- point `pytest` at the whole `tests` folder for broader discovery
- define and export `MATERIAL_COMPONENTS_COUNT` and validate material IDs
- clean up renderer helpers and type/lint configs so linters run cleanly

## Testing
- `pytest -q`
- `mypy`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4edc4d524832da1e19ac6a2df2cf5