### PR TITLE
refactor: simplify mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,5 @@
 [mypy]
 ignore_missing_imports = True
-files = src
-exclude = ^src/physics/
-
-
 explicit_package_bases = True
 files = src
-exclude = (tests/|src/physics/)
-        main
+exclude = ^(src/physics/|tests/)


### PR DESCRIPTION
## Summary
- simplify mypy configuration by removing duplicates

## Testing
- `pytest` *(fails: NameError: name 'MATERIAL_COMPONENTS_COUNT' is not defined)*
- `npx eslint .` *(fails: SyntaxError in eslint.config.cjs)*
- `mypy` *(fails: incompatible type and name already defined errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee006eb8832db877443afd08407a