### PR TITLE
fix: clean up ESLint config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,18 +1,13 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
       'build/**',
@@ -27,8 +22,7 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-    ]
-  }
+      'scripts/**',
+    ],
+  },
 ];
-        main


### PR DESCRIPTION
## Summary
- remove stray text and duplicate sections in ESLint configuration
- export a single configuration array with language options and ignore list

## Testing
- `npx eslint .`
- `npm test` (fails: Error: no test specified)
- `pytest -q` (fails: name 'MATERIAL_COMPONENTS_COUNT' is not defined)
- `mypy` (fails: option 'files' in section 'mypy' already exists)


------
https://chatgpt.com/codex/tasks/task_e_68a4ee030cb8832d805eca1621df8312