### PR TITLE
Add placeholder player controller capsule test

### DIFF
--- a/tests/test_player_controller_capsule.py
+++ b/tests/test_player_controller_capsule.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+
+try:
+    from src.physics.player_controller_capsule import (
+        PlayerControllerCapsule,
+        SPRINT_SPEED_MULTIPLIER,
+        get_horizontal_speed,
+    )
+except Exception:
+    pytest.skip(
+        "player controller capsule requires native physics extensions; skipped in CI",
+        allow_module_level=True,
+    )
+
+
+def test_horizontal_speed_zero_initially() -> None:
+    controller = PlayerControllerCapsule(
+        world_manager=None,
+        spawn=np.zeros(3, dtype=np.float32),
+    )
+    assert get_horizontal_speed(controller) == 0.0
+    assert SPRINT_SPEED_MULTIPLIER > 1.0


### PR DESCRIPTION
## Summary
- add capsule controller test that skips when native physics extensions are missing

## Testing
- `pytest tests/test_player_controller_capsule.py`
- `pytest`
- `npx eslint .` *(fails: SyntaxError in config file)*
- `mypy --config-file /tmp/mypy.ini --follow-imports=skip -v tests/test_player_controller_capsule.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4eea16d78832dac07dea2e0f169cf