### PR TITLE
chore: refine mypy config

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,18 +1,13 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
       'build/**',
@@ -27,8 +22,7 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-    ]
-  }
+      'scripts/**',
+    ],
+  },
 ];
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,10 @@
 [mypy]
-ignore_missing_imports = True
-files = src
-exclude = ^src/physics/
-
-
-explicit_package_bases = True
 files = src
 exclude = (tests/|src/physics/)
-        main
+explicit_package_bases = True
+
+[mypy-zstandard]
+ignore_missing_imports = True
+
+[mypy-lz4.*]
+ignore_missing_imports = True

--- a/src/renderer/ibl.py
+++ b/src/renderer/ibl.py
@@ -3,14 +3,6 @@
 
 from .material_manager import MaterialManager
 
-_manager = MaterialManager()
-
-
-def build_brdf_lut(material_name: str, *args, **kwargs):
-    """Build a BRDF lookup texture for the given material."""
-
-
-
 
 def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs):
     """Build a BRDF lookup texture for the given material."""

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -33,7 +33,12 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            albedo_list = props.get("albedo", [1.0, 1.0, 1.0])
+            albedo = (
+                float(albedo_list[0]),
+                float(albedo_list[1]),
+                float(albedo_list[2]),
+            )
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,5 +1,9 @@
 from src.renderer.material_manager import MaterialManager
 
+# Each material is represented by RGB albedo plus metallic and roughness
+# components, resulting in five floats per material.
+MATERIAL_COMPONENTS_COUNT = 5
+
 
 def test_material_manager_loads_and_ids_unique():
     mgr = MaterialManager()


### PR DESCRIPTION
## Summary
- remove global mypy ignore_missing_imports and add per-module ignores for zstandard and lz4
- fix type warnings and cleanup renderer helpers
- define material components constant for tests
- restore valid ESLint configuration

## Testing
- `npx eslint .`
- `pytest`
- `mypy --config-file mypy.ini`


------
https://chatgpt.com/codex/tasks/task_e_68a4eea083ec832da87782200ef45b77