### PR TITLE
Add spacing in codec flags and define material constant

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,18 +1,13 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
       'build/**',
@@ -27,8 +22,7 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-    ]
-  }
+      'scripts/**',
+    ],
+  },
 ];
-        main

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
+
+MATERIAL_COMPONENTS_COUNT = 5
 
 
 @dataclass
@@ -33,7 +35,10 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            raw_albedo = props.get("albedo", [1.0, 1.0, 1.0])[:3]
+            albedo = cast(
+                Tuple[float, float, float], tuple(float(x) for x in raw_albedo)
+            )
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)
@@ -47,6 +52,7 @@ class MaterialManager:
         if name not in self._materials_by_name:
             raise ValueError(f"Material {name} not found")
         return self._materials_by_name[name].id
+
     def get_material(self, material_id: int) -> Material:
         """Fetch material properties by ID."""
 
@@ -65,7 +71,4 @@ class MaterialManager:
     def create_gpu_resources(self) -> List[Tuple[float, float, float, float, float]]:
         """Package materials into a flat list suitable for GPU upload."""
 
-        return [
-            (*m.albedo, m.metallic, m.roughness) for m in self._materials_by_id
-        ]
-
+        return [(*m.albedo, m.metallic, m.roughness) for m in self._materials_by_id]

--- a/src/world/persistence.py
+++ b/src/world/persistence.py
@@ -1,4 +1,3 @@
-
 import json
 import logging
 import numpy as np
@@ -9,37 +8,53 @@ from .rle import rle_encode, rle_decode
 
 try:
     import zstandard as zstd
-    has_zstd=True
+
+    has_zstd = True
 except Exception:
-    has_zstd=False
+    has_zstd = False
 try:
     import lz4.frame as lz4f
-    has_lz4=True
+
+    has_lz4 = True
 except Exception:
-    has_lz4=False
+    has_lz4 = False
+
 
 class ChunkStore:
     def __init__(self, root="world_save", codec="zstd", use_rle=True, threads=4):
-        self.root = Path(root); self.root.mkdir(parents=True, exist_ok=True)
-        self.codec = codec; self.use_rle = use_rle
-        self.pool = ThreadPoolExecutor(max_workers=max(1,threads))
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.codec = codec
+        self.use_rle = use_rle
+        self.pool = ThreadPoolExecutor(max_workers=max(1, threads))
         self.futures: Dict[str, Future] = {}
 
     def _region_dir(self, cx, cz):
-        d = self.root / f"r.{cx//32}.{cz//32}"; d.mkdir(exist_ok=True); return d
-    def chunk_path(self, cx, cz): return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
+        d = self.root / f"r.{cx//32}.{cz//32}"
+        d.mkdir(exist_ok=True)
+        return d
+
+    def chunk_path(self, cx, cz):
+        return self._region_dir(cx, cz) / f"c.{cx}.{cz}.bin"
 
     def _compress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
-            c = zstd.ZstdCompressor(level=10); return c.compress(b)
-        if self.codec=="lz4" and has_lz4:
-            return lz4f.compress(b, compression_level=9, block_size=lz4f.BLOCKSIZE_MAX1MB, content_checksum=True)
+        if self.codec == "zstd" and has_zstd:
+            c = zstd.ZstdCompressor(level=10)
+            return c.compress(b)
+        if self.codec == "lz4" and has_lz4:
+            return lz4f.compress(
+                b,
+                compression_level=9,
+                block_size=lz4f.BLOCKSIZE_MAX1MB,
+                content_checksum=True,
+            )
         return b
 
     def _decompress(self, b: bytes) -> bytes:
-        if self.codec=="zstd" and has_zstd:
-            d = zstd.ZstdDecompressor(); return d.decompress(b)
-        if self.codec=="lz4" and has_lz4:
+        if self.codec == "zstd" and has_zstd:
+            d = zstd.ZstdDecompressor()
+            return d.decompress(b)
+        if self.codec == "lz4" and has_lz4:
             return lz4f.decompress(b)
         return b
 
@@ -49,11 +64,16 @@ class ChunkStore:
             vox = chunk.voxels.astype(np.uint8)
             if self.use_rle:
                 vals, counts, shape = rle_encode(vox)
-                header = np.array([shape[0], shape[1], shape[2], vals.size, counts.size], dtype=np.int32).tobytes()
+                header = np.array(
+                    [shape[0], shape[1], shape[2], vals.size, counts.size],
+                    dtype=np.int32,
+                ).tobytes()
                 payload = vals.tobytes() + counts.tobytes()
                 data = header + payload
             else:
-                header = np.array([vox.shape[0], vox.shape[1], vox.shape[2], 0, 0], dtype=np.int32).tobytes()
+                header = np.array(
+                    [vox.shape[0], vox.shape[1], vox.shape[2], 0, 0], dtype=np.int32
+                ).tobytes()
                 data = header + vox.tobytes()
             blob = self._compress(data)
             self.chunk_path(cx, cz).write_bytes(blob)
@@ -81,18 +101,19 @@ class ChunkStore:
 
     def load_chunk(self, cx, cz) -> Optional[Dict]:
         p = self.chunk_path(cx, cz)
-        if not p.exists(): return None
+        if not p.exists():
+            return None
         blob = p.read_bytes()
         raw = self._decompress(blob)
         header = np.frombuffer(raw[:20], dtype=np.int32)
         H, Y, S, nvals, ncnt = header.tolist()
         rest = raw[20:]
-        if nvals>0:
+        if nvals > 0:
             vals = np.frombuffer(rest[:nvals], dtype=np.uint8)
-            counts = np.frombuffer(rest[nvals:nvals+4*ncnt], dtype=np.int32)
-            vox = rle_decode(vals, counts, (H,Y,S))
+            counts = np.frombuffer(rest[nvals : nvals + 4 * ncnt], dtype=np.int32)
+            vox = rle_decode(vals, counts, (H, Y, S))
         else:
-            vox = np.frombuffer(rest, dtype=np.uint8).reshape((H,Y,S))
+            vox = np.frombuffer(rest, dtype=np.uint8).reshape((H, Y, S))
         return {"voxels": vox, "height": int(Y), "size": int(S)}
 
     def wait_all(self):

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,4 +1,4 @@
-from src.renderer.material_manager import MaterialManager
+from src.renderer.material_manager import MaterialManager, MATERIAL_COMPONENTS_COUNT
 
 
 def test_material_manager_loads_and_ids_unique():
@@ -13,4 +13,3 @@ def test_material_manager_gpu_resources_shape():
     resources = mgr.create_gpu_resources()
     assert len(resources) == len(mgr.materials())
     assert all(len(r) == MATERIAL_COMPONENTS_COUNT for r in resources)
-


### PR DESCRIPTION
## Summary
- format persistence codec feature flags with spaces around assignments
- define MATERIAL_COMPONENTS_COUNT and tighten MaterialManager albedo typing
- fix ESLint config and tests to satisfy linting and type checks

## Testing
- `black --check src/world/persistence.py`
- `black --check src/renderer/material_manager.py`
- `black --check tests/test_material_manager.py`
- `pytest`
- `mypy --ignore-missing-imports --explicit-package-bases src/world/persistence.py src/renderer/material_manager.py tests/test_material_manager.py`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee9f8760832db7683ac8633a8448