### PR TITLE
refactor: clean lint and type configs

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,18 +1,13 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
-      globals: { ...globals.node, ...globals.es2021 }
+      globals: { ...globals.node, ...globals.es2021 },
     },
     ignores: [
       'build/**',
@@ -27,8 +22,7 @@ module.exports = [
       'tests/**',
       'src/**',
       'apps/**',
-      'scripts/**'
-    ]
-  }
+      'scripts/**',
+    ],
+  },
 ];
-        main

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,5 @@
 [mypy]
 ignore_missing_imports = True
 files = src
-exclude = ^src/physics/
-
-
-explicit_package_bases = True
-files = src
 exclude = (tests/|src/physics/)
-        main
+explicit_package_bases = True

--- a/src/renderer/ibl.py
+++ b/src/renderer/ibl.py
@@ -6,13 +6,12 @@ from .material_manager import MaterialManager
 _manager = MaterialManager()
 
 
-def build_brdf_lut(material_name: str, *args, **kwargs):
-    """Build a BRDF lookup texture for the given material."""
-
-
-
-
-def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs):
+def build_brdf_lut(
+    material_name: str,
+    manager: MaterialManager = _manager,
+    *args,
+    **kwargs,
+) -> None:
     """Build a BRDF lookup texture for the given material."""
 
     material_id = manager.get_material_id(material_name)

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
+
+
+MATERIAL_COMPONENTS_COUNT = 5
 
 
 @dataclass
@@ -33,7 +36,10 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            albedo = cast(
+                Tuple[float, float, float],
+                tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0])),
+            )
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)
@@ -43,7 +49,6 @@ class MaterialManager:
     def get_material_id(self, name: str) -> int:
         """Return the numeric ID for a material name."""
 
-        return self._materials_by_name[name].id
         if name not in self._materials_by_name:
             raise ValueError(f"Material {name} not found")
         return self._materials_by_name[name].id

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,4 +1,7 @@
-from src.renderer.material_manager import MaterialManager
+from src.renderer.material_manager import (
+    MATERIAL_COMPONENTS_COUNT,
+    MaterialManager,
+)
 
 
 def test_material_manager_loads_and_ids_unique():


### PR DESCRIPTION
## Summary
- consolidate eslint config into single export with defined language options and ignore list
- streamline mypy configuration
- add material component count constant and cleanup renderer helpers

## Testing
- `npx eslint .`
- `pytest`
- `mypy`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee618d94832d84a0b354e4c65c5d