### PR TITLE
Refine mypy config and resolve type issues

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,14 +1,9 @@
 const js = require('@eslint/js');
 const globals = require('globals');
-        main
 
 module.exports = [
   js.configs.recommended,
   {
-    ignores: ['node_modules/**'],
-  },
-];
-
     languageOptions: {
       ecmaVersion: 2021,
       sourceType: 'script',
@@ -31,4 +26,4 @@ module.exports = [
     ]
   }
 ];
-        main
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,10 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-files = src
-exclude = ^src/physics/
-
-
 explicit_package_bases = True
 files = src
-exclude = (tests/|src/physics/)
-        main
+exclude = ^(src/physics/|tests/)
+

--- a/src/renderer/ibl.py
+++ b/src/renderer/ibl.py
@@ -1,15 +1,8 @@
-
 """Image based lighting helpers."""
 
 from .material_manager import MaterialManager
 
 _manager = MaterialManager()
-
-
-def build_brdf_lut(material_name: str, *args, **kwargs):
-    """Build a BRDF lookup texture for the given material."""
-
-
 
 
 def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs):
@@ -19,3 +12,4 @@ def build_brdf_lut(material_name: str, manager: MaterialManager, *args, **kwargs
     raise NotImplementedError(
         f"Implement using your rendering backend (material id {material_id})."
     )
+

--- a/src/renderer/material_manager.py
+++ b/src/renderer/material_manager.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, cast
+
+MATERIAL_COMPONENTS_COUNT = 5
 
 
 @dataclass
@@ -33,7 +35,11 @@ class MaterialManager:
         self._materials_by_name.clear()
         self._materials_by_id.clear()
         for idx, (name, props) in enumerate(mats.items()):
-            albedo = tuple(float(x) for x in props.get("albedo", [1.0, 1.0, 1.0]))
+            albedo_list = props.get("albedo", [1.0, 1.0, 1.0])[:3]
+            albedo = cast(
+                Tuple[float, float, float],
+                tuple(float(x) for x in albedo_list),
+            )
             metallic = float(props.get("metallic", 0.0))
             roughness = float(props.get("roughness", 1.0))
             mat = Material(idx, albedo, metallic, roughness)
@@ -43,9 +49,6 @@ class MaterialManager:
     def get_material_id(self, name: str) -> int:
         """Return the numeric ID for a material name."""
 
-        return self._materials_by_name[name].id
-        if name not in self._materials_by_name:
-            raise ValueError(f"Material {name} not found")
         return self._materials_by_name[name].id
     def get_material(self, material_id: int) -> Material:
         """Fetch material properties by ID."""

--- a/tests/test_material_manager.py
+++ b/tests/test_material_manager.py
@@ -1,4 +1,7 @@
-from src.renderer.material_manager import MaterialManager
+from src.renderer.material_manager import (
+    MaterialManager,
+    MATERIAL_COMPONENTS_COUNT,
+)
 
 
 def test_material_manager_loads_and_ids_unique():


### PR DESCRIPTION
## Summary
- streamline mypy configuration and ignore physics and test modules
- clean up ESLint config and remove duplicate BRDF LUT stub
- tighten MaterialManager typing and expose MATERIAL_COMPONENTS_COUNT

## Testing
- `npx eslint .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee604ba0832d93323215738c2ee1